### PR TITLE
Add PPO benchmarking

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/runtime",
     "crates/physics",
     "crates/ml",
+    "crates/rl",
 ]
 resolver = "2"
 

--- a/crates/compute/src/layout.rs
+++ b/crates/compute/src/layout.rs
@@ -9,7 +9,8 @@ const _: () = assert!(STORAGE_OUT == 2);
 pub const fn binding_count(kernel: &crate::Kernel) -> u32 {
     match kernel {
         crate::Kernel::SphereStep => 2,
-        crate::Kernel::Add | crate::Kernel::Mul | crate::Kernel::Where => 4,
+        crate::Kernel::Add | crate::Kernel::Mul | crate::Kernel::Sub | crate::Kernel::Div | crate::Kernel::Where => 4,
+        crate::Kernel::Exp | crate::Kernel::Log | crate::Kernel::Tanh => 3,
         crate::Kernel::ReduceSum => 3,
         crate::Kernel::MatMul => 3,
     }

--- a/crates/ml/tests/tensor_ops.rs
+++ b/crates/ml/tests/tensor_ops.rs
@@ -44,3 +44,23 @@ fn test_add_mul_where() {
         .fold(0.0_f32, |m, (x, y)| m.max((x - y).abs()));
     assert!(max_diff3 < 1e-6);
 }
+
+#[test]
+fn test_sub_div_exp() {
+    let a = Tensor::from_vec(vec![4], vec![1.0, 2.0, 3.0, 4.0]);
+    let b = Tensor::from_vec(vec![4], vec![4.0, 3.0, 2.0, 1.0]);
+    let out = Tensor::from_vec(vec![4], vec![0.0;4]);
+    let res = run_single(OpCall{ op: Op::Sub, a: a.clone(), b: b.clone(), out });
+    let expected: Vec<f32> = a.data.iter().zip(&b.data).map(|(x,y)| x - y).collect();
+    for (o,e) in res.data.iter().zip(expected) { assert!((o-e).abs() < 1e-6); }
+
+    let out2 = Tensor::from_vec(vec![4], vec![0.0;4]);
+    let res2 = run_single(OpCall{ op: Op::Div, a: a.clone(), b: b.clone(), out: out2 });
+    let expected2: Vec<f32> = a.data.iter().zip(&b.data).map(|(x,y)| x / y).collect();
+    for (o,e) in res2.data.iter().zip(expected2) { assert!((o-e).abs() < 1e-6); }
+
+    let out3 = Tensor::from_vec(vec![4], vec![0.0;4]);
+    let res3 = run_single(OpCall{ op: Op::Exp, a: a.clone(), b: Tensor::from_vec(vec![4], vec![0.0;4]), out: out3 });
+    let expected3: Vec<f32> = a.data.iter().map(|x| x.exp()).collect();
+    for (o,e) in res3.data.iter().zip(expected3) { assert!((o-e).abs() < 1e-6); }
+}

--- a/crates/rl/Cargo.toml
+++ b/crates/rl/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "rl"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+ml = { path = "../ml" }
+physics = { path = "../physics" }
+
+[dev-dependencies]
+criterion = "0.5"
+sysinfo = "0.35"
+
+[[bench]]
+name = "ppo"
+harness = false

--- a/crates/rl/benches/ppo.rs
+++ b/crates/rl/benches/ppo.rs
@@ -1,0 +1,33 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use rl::env::SimpleEnv;
+use rl::ppo::PpoAgent;
+use ml::Tensor;
+use sysinfo::System;
+
+fn bench_ppo_train_step(c: &mut Criterion) {
+    let env = SimpleEnv::new(1.0);
+    let obs = Tensor::from_vec(vec![1], vec![0.0]);
+    c.bench_function("ppo_train_step", |b| {
+        let mut agent = PpoAgent::new(0.01);
+        b.iter(|| {
+            let mut state = env.reset();
+            let action = agent.act(&obs);
+            let advantage = env.target - action;
+            agent.update(&obs, action, advantage);
+        });
+    });
+
+    // Print hardware stats
+    let mut sys = System::new_all();
+    let cpu_brand = sys
+        .cpus()
+        .first()
+        .map(|c| c.brand())
+        .unwrap_or("unknown");
+    let cores = System::physical_core_count().unwrap_or(sys.cpus().len());
+    let mem_mb = sys.total_memory() / 1024;
+    println!("Hardware: {} with {} cores, {} MB RAM", cpu_brand, cores, mem_mb);
+}
+
+criterion_group!(benches, bench_ppo_train_step);
+criterion_main!(benches);

--- a/crates/rl/src/env.rs
+++ b/crates/rl/src/env.rs
@@ -1,0 +1,19 @@
+/// Very simple environment where the optimal action equals a target value.
+/// State is ignored and episodes last a single step.
+#[derive(Clone)]
+pub struct SimpleEnv {
+    pub target: f32,
+}
+
+impl SimpleEnv {
+    #[must_use]
+    pub fn new(target: f32) -> Self { Self { target } }
+
+    #[must_use]
+    pub fn reset(&self) -> () { () }
+
+    pub fn step(&self, _state: &mut (), action: f32) -> ((), f32, bool) {
+        let reward = -(action - self.target).powi(2);
+        ((), reward, true)
+    }
+}

--- a/crates/rl/src/lib.rs
+++ b/crates/rl/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod env;
+pub mod ppo;

--- a/crates/rl/src/ppo.rs
+++ b/crates/rl/src/ppo.rs
@@ -1,0 +1,31 @@
+use ml::{Dense, Tensor, Graph};
+
+pub struct PpoAgent {
+    policy: Dense,
+    lr: f32,
+}
+
+impl PpoAgent {
+    #[must_use]
+    pub fn new(lr: f32) -> Self {
+        // single-input linear policy
+        let weights = vec![0.0];
+        let bias = vec![0.0];
+        Self { policy: Dense::new(weights, bias, 1, 1), lr }
+    }
+
+    #[must_use]
+    pub fn act(&self, obs: &Tensor) -> f32 {
+        let mut g = Graph::default();
+        let out = self.policy.forward(obs, &mut g);
+        out.data[0]
+    }
+
+    pub fn update(&mut self, obs: &Tensor, action: f32, advantage: f32) {
+        // gradient of linear layer w.r.t weights is obs * advantage
+        let grad = obs.data[0] * advantage;
+        self.policy.w.data[0] += self.lr * grad;
+        // bias gradient
+        self.policy.b.data[0] += self.lr * advantage;
+    }
+}

--- a/crates/rl/tests/ppo_train.rs
+++ b/crates/rl/tests/ppo_train.rs
@@ -1,0 +1,26 @@
+use rl::env::SimpleEnv;
+use rl::ppo::PpoAgent;
+use ml::Tensor;
+
+#[test]
+fn ppo_training_reduces_error() {
+    let env = SimpleEnv::new(1.0);
+    let mut state = env.reset();
+    let mut agent = PpoAgent::new(0.01);
+    let obs = Tensor::from_vec(vec![1], vec![0.0]);
+    let mut action = agent.act(&obs);
+    let (_, reward, _) = env.step(&mut state, action);
+    let mut prev_loss = -reward;
+    let start_loss = prev_loss;
+    for _ in 0..50 {
+        let mut advantage = env.target - action;
+        if advantage > 10.0 { advantage = 10.0; }
+        if advantage < -10.0 { advantage = -10.0; }
+        agent.update(&obs, action, advantage);
+        action = agent.act(&obs);
+        let (_, reward, _) = env.step(&mut state, action);
+        prev_loss = -reward;
+    }
+    eprintln!("start_loss {start_loss} final_loss {prev_loss}");
+    assert!(prev_loss < start_loss, "agent should learn to reduce loss");
+}


### PR DESCRIPTION
## Summary
- add `criterion` benchmark for PPO training loop
- print hardware stats during benchmark execution
- add benchmark dependencies for `rl` crate

## Testing
- `cargo test --all`
- `cargo bench -p rl --bench ppo -- --noplot`


------
https://chatgpt.com/codex/tasks/task_e_68414b2359b083219bc8ef82c9ffc0cd