### PR TITLE
Enable runtime GPU fallback

### DIFF
--- a/crates/ml/src/lib.rs
+++ b/crates/ml/src/lib.rs
@@ -42,7 +42,7 @@ impl Default for Graph { fn default() -> Self { Self { calls: Vec::new() } } }
 impl Graph {
     pub fn add_call(&mut self, call: OpCall) { self.calls.push(call); }
 
-    pub fn run(&mut self, backend: &impl ComputeBackend) -> Result<(), ComputeError> {
+    pub fn run<B: ComputeBackend + ?Sized>(&mut self, backend: &B) -> Result<(), ComputeError> {
         for call in &mut self.calls {
             let len = call.out.len();
             let a_view = upload(&mut call.a);

--- a/crates/ml/tests/tensor_ops.rs
+++ b/crates/ml/tests/tensor_ops.rs
@@ -1,10 +1,11 @@
 use ml::{Graph, Tensor, Op, OpCall};
-use compute::MockCpu;
+use compute::default_backend;
 
 fn run_single(call: OpCall) -> Tensor {
     let mut g = Graph::default();
     g.add_call(call);
-    g.run(&MockCpu).unwrap();
+    let backend = default_backend();
+    g.run(backend.as_ref()).unwrap();
     g.calls.pop().unwrap().out
 }
 

--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -90,7 +90,7 @@ impl PhysicsSim {
             force: [0.0, 0.0],
         };
 
-        let backend = Arc::new(compute::MockCpu);
+        let backend = compute::default_backend();
 
         Self {
             spheres,
@@ -197,12 +197,12 @@ mod tests {
 
     // Unit test for step_gpu (will fail or do nothing until step_gpu is implemented)
     #[test]
-    fn test_step_gpu_mock_ok_with_valid_buffers() {
+    fn test_step_gpu_default_backend_ok_with_valid_buffers() {
         let mut sim = PhysicsSim::new_single_sphere(5.0);
         let result = sim.step_gpu();
-        assert!(result.is_ok(), "step_gpu with MockCpu should return Ok if buffers are valid, got {result:?}");
-        // Further assertions could check if MockCpu (if it modified anything) did correctly.
-        // For now, MockCpu in compute crate only does shape checks and returns Ok if shapes are fine.
+        assert!(result.is_ok(), "step_gpu should return Ok if buffers are valid, got {result:?}");
+        // Further assertions could check if the backend (mock or real GPU) behaved correctly.
+        // For now, the mock backend only performs shape checks and returns Ok if shapes are fine.
         // The actual step_gpu implementation will involve creating BufferViews and calling dispatch.
         // This test will become more meaningful once step_gpu does that.
     }

--- a/crates/runtime/tests/shader_compile.rs
+++ b/crates/runtime/tests/shader_compile.rs
@@ -38,19 +38,19 @@ fn validate_wgsl_shader(shader_path_str: &str) {
 
 #[test]
 fn validate_noop_shader_compiles() {
-    let _mock_cpu_instance = compute::MockCpu;
+    let _backend = compute::default_backend();
     validate_wgsl_shader("../../shaders/noop.wgsl");
 }
 
 #[test]
 fn validate_integrate_euler_shader_compiles() {
-    let _mock_cpu_instance_2 = compute::MockCpu;
+    let _backend = compute::default_backend();
     validate_wgsl_shader("../../shaders/integrate_euler.wgsl");
 }
 
 #[test]
 fn validate_elementwise_shader_compiles() {
-    let _mock_cpu_instance_3 = compute::MockCpu;
+    let _backend = compute::default_backend();
     validate_wgsl_shader("../../shaders/elementwise.wgsl");
 }
 


### PR DESCRIPTION
## Summary
- add `default_backend` helper for compute
- use `default_backend` in physics simulation setup
- update tests to rely on the helper
- allow Graph to accept dynamic backend

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_e_684151181cb08321a2f013a5a94fe146