### PR TITLE
Add comprehensive tests for ML modules

### DIFF
--- a/crates/ml/Cargo.toml
+++ b/crates/ml/Cargo.toml
@@ -6,3 +6,4 @@ edition = "2021"
 [dependencies]
 compute = { path = "../compute", features = ["mock"] }
 bytemuck = { version = "1.15", features = ["derive"] }
+rand = "0.8"

--- a/crates/ml/src/lib.rs
+++ b/crates/ml/src/lib.rs
@@ -1,6 +1,7 @@
 use compute::{BufferView, ComputeBackend, ComputeError, Kernel};
 use std::sync::Arc;
 use bytemuck;
+use rand::{distributions::Uniform, Rng};
 
 #[derive(Clone)]
 pub struct Tensor {
@@ -115,6 +116,14 @@ impl Dense {
         }
     }
 
+    pub fn xavier(in_dim: usize, out_dim: usize, rng: &mut impl Rng) -> Self {
+        let limit = (6.0f32 / (in_dim as f32 + out_dim as f32)).sqrt();
+        let dist = Uniform::new(-limit, limit);
+        let weights: Vec<f32> = (0..in_dim * out_dim).map(|_| rng.sample(dist)).collect();
+        let bias = vec![0.0; out_dim];
+        Self::new(weights, bias, in_dim, out_dim)
+    }
+
     pub fn forward(&self, x: &Tensor, g: &mut Graph) -> Tensor {
         let mut y = vec![0f32; self.out_dim];
         for o in 0..self.out_dim {
@@ -127,3 +136,274 @@ impl Dense {
         Tensor::from_vec(vec![self.out_dim], y)
     }
 }
+
+// Trait representing a differentiable layer
+pub trait Layer {
+    fn forward(&self, x: &Tensor, g: &mut Graph) -> Tensor;
+    fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Vec<Tensor>);
+    fn params(&self) -> Vec<&Tensor> { Vec::new() }
+    fn params_mut(&mut self) -> Vec<&mut Tensor> { Vec::new() }
+}
+
+impl Layer for Dense {
+    fn forward(&self, x: &Tensor, g: &mut Graph) -> Tensor { self.forward(x, g) }
+    fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Vec<Tensor>) {
+        let (dx, dw, db) = self.backward(x, grad);
+        (dx, vec![dw, db])
+    }
+    fn params(&self) -> Vec<&Tensor> { vec![&self.w, &self.b] }
+    fn params_mut(&mut self) -> Vec<&mut Tensor> { vec![&mut self.w, &mut self.b] }
+}
+
+impl Dense {
+    pub fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Tensor, Tensor) {
+        let mut grad_input = vec![0.0; self.in_dim];
+        let mut grad_w = vec![0.0; self.in_dim * self.out_dim];
+        let mut grad_b = vec![0.0; self.out_dim];
+        for o in 0..self.out_dim {
+            let go = grad.data[o];
+            for i in 0..self.in_dim {
+                grad_w[o * self.in_dim + i] += go * x.data[i];
+                grad_input[i] += self.w.data[o * self.in_dim + i] * go;
+            }
+            grad_b[o] += go;
+        }
+        (
+            Tensor::from_vec(vec![self.in_dim], grad_input),
+            Tensor::from_vec(vec![self.out_dim, self.in_dim], grad_w),
+            Tensor::from_vec(vec![self.out_dim], grad_b),
+        )
+    }
+}
+
+#[derive(Default)]
+pub struct Relu;
+
+impl Layer for Relu {
+    fn forward(&self, x: &Tensor, _g: &mut Graph) -> Tensor {
+        let data: Vec<f32> = x.data.iter().map(|&v| v.max(0.0)).collect();
+        Tensor::from_vec(x.shape.clone(), data)
+    }
+
+    fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Vec<Tensor>) {
+        let data: Vec<f32> = x
+            .data
+            .iter()
+            .zip(&grad.data)
+            .map(|(&v, &g)| if v > 0.0 { g } else { 0.0 })
+            .collect();
+        (Tensor::from_vec(x.shape.clone(), data), Vec::new())
+    }
+}
+
+#[derive(Default)]
+pub struct Sigmoid;
+
+impl Layer for Sigmoid {
+    fn forward(&self, x: &Tensor, _g: &mut Graph) -> Tensor {
+        let data: Vec<f32> = x.data.iter().map(|&v| 1.0 / (1.0 + (-v).exp())).collect();
+        Tensor::from_vec(x.shape.clone(), data)
+    }
+
+    fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Vec<Tensor>) {
+        let forward = self.forward(x, &mut Graph::default());
+        let data: Vec<f32> = forward
+            .data
+            .iter()
+            .zip(&grad.data)
+            .map(|(&s, &g)| g * s * (1.0 - s))
+            .collect();
+        (Tensor::from_vec(x.shape.clone(), data), Vec::new())
+    }
+}
+
+#[derive(Default)]
+pub struct TanhAct;
+
+impl Layer for TanhAct {
+    fn forward(&self, x: &Tensor, _g: &mut Graph) -> Tensor {
+        let data: Vec<f32> = x.data.iter().map(|&v| v.tanh()).collect();
+        Tensor::from_vec(x.shape.clone(), data)
+    }
+
+    fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Vec<Tensor>) {
+        let forward = self.forward(x, &mut Graph::default());
+        let data: Vec<f32> = forward
+            .data
+            .iter()
+            .zip(&grad.data)
+            .map(|(&t, &g)| g * (1.0 - t * t))
+            .collect();
+        (Tensor::from_vec(x.shape.clone(), data), Vec::new())
+    }
+}
+
+pub struct Softmax;
+
+impl Layer for Softmax {
+    fn forward(&self, x: &Tensor, _g: &mut Graph) -> Tensor {
+        let m = x.data.iter().cloned().fold(f32::NEG_INFINITY, f32::max);
+        let exp: Vec<f32> = x.data.iter().map(|&v| (v - m).exp()).collect();
+        let sum: f32 = exp.iter().sum();
+        let data: Vec<f32> = exp.iter().map(|&e| e / sum).collect();
+        Tensor::from_vec(x.shape.clone(), data)
+    }
+
+    fn backward(&self, x: &Tensor, grad: &Tensor) -> (Tensor, Vec<Tensor>) {
+        let sm = self.forward(x, &mut Graph::default());
+        let n = sm.data.len();
+        let mut result = vec![0.0f32; n];
+        for i in 0..n {
+            for j in 0..n {
+                let delta = if i == j { 1.0 } else { 0.0 };
+                result[j] += grad.data[i] * sm.data[i] * (delta - sm.data[j]);
+            }
+        }
+        (Tensor::from_vec(x.shape.clone(), result), Vec::new())
+    }
+}
+
+pub struct Sequential {
+    layers: Vec<Box<dyn Layer>>,
+}
+
+impl Sequential {
+    #[must_use]
+    pub fn new() -> Self { Self { layers: Vec::new() } }
+
+    pub fn push<L: Layer + 'static>(&mut self, layer: L) { self.layers.push(Box::new(layer)); }
+
+    pub fn forward(&self, x: &Tensor, g: &mut Graph) -> (Tensor, Vec<Tensor>) {
+        let mut out = x.clone();
+        let mut activations = vec![out.clone()];
+        for layer in &self.layers {
+            out = layer.forward(&out, g);
+            activations.push(out.clone());
+        }
+        (out, activations)
+    }
+
+    pub fn backward(&self, activations: &[Tensor], grad: &Tensor) -> (Tensor, Vec<Tensor>) {
+        let mut grad_out = grad.clone();
+        let mut param_grads = Vec::new();
+        for (layer, activation) in self
+            .layers
+            .iter()
+            .rev()
+            .zip(activations.iter().rev().skip(1))
+        {
+            let (g_in, mut p) = layer.backward(activation, &grad_out);
+            grad_out = g_in;
+            param_grads.extend(p);
+        }
+        (grad_out, param_grads)
+    }
+
+    pub fn params_mut(&mut self) -> Vec<&mut Tensor> {
+        let mut out = Vec::new();
+        for layer in &mut self.layers {
+            out.extend(layer.params_mut());
+        }
+        out
+    }
+}
+
+pub struct Sgd { pub lr: f32 }
+
+impl Sgd {
+    #[must_use]
+    pub fn new(lr: f32) -> Self { Self { lr } }
+
+    pub fn step(&self, params: &mut [(&mut Tensor, &Tensor)]) {
+        for (p, g) in params {
+            for (pv, gv) in p.data.iter_mut().zip(&g.data) {
+                *pv -= self.lr * gv;
+            }
+        }
+    }
+}
+
+pub struct Adam {
+    lr: f32,
+    beta1: f32,
+    beta2: f32,
+    eps: f32,
+    t: usize,
+    m: Vec<Vec<f32>>,
+    v: Vec<Vec<f32>>,
+}
+
+impl Adam {
+    #[must_use]
+    pub fn new(lr: f32) -> Self {
+        Self { lr, beta1: 0.9, beta2: 0.999, eps: 1e-8, t: 0, m: Vec::new(), v: Vec::new() }
+    }
+
+    pub fn step(&mut self, params: &mut [(&mut Tensor, &Tensor)]) {
+        if self.m.is_empty() {
+            self.m = params.iter().map(|(p, _)| vec![0.0; p.len()]).collect();
+            self.v = params.iter().map(|(p, _)| vec![0.0; p.len()]).collect();
+        }
+        self.t += 1;
+        for ((p, g), (m_vec, v_vec)) in params.iter_mut().zip(self.m.iter_mut().zip(self.v.iter_mut())) {
+            for i in 0..p.len() {
+                m_vec[i] = self.beta1 * m_vec[i] + (1.0 - self.beta1) * g.data[i];
+                v_vec[i] = self.beta2 * v_vec[i] + (1.0 - self.beta2) * g.data[i] * g.data[i];
+                let m_hat = m_vec[i] / (1.0 - self.beta1.powi(self.t as i32));
+                let v_hat = v_vec[i] / (1.0 - self.beta2.powi(self.t as i32));
+                p.data[i] -= self.lr * m_hat / (v_hat.sqrt() + self.eps);
+            }
+        }
+    }
+}
+
+pub struct PolicyNetwork {
+    pub net: Sequential,
+}
+
+impl PolicyNetwork {
+    #[must_use]
+    pub fn new(net: Sequential) -> Self { Self { net } }
+
+    pub fn act(&self, obs: &Tensor) -> Tensor {
+        let mut g = Graph::default();
+        self.net.forward(obs, &mut g).0
+    }
+}
+
+pub struct ValueNetwork {
+    pub net: Sequential,
+}
+
+impl ValueNetwork {
+    #[must_use]
+    pub fn new(net: Sequential) -> Self { Self { net } }
+
+    pub fn value(&self, obs: &Tensor) -> Tensor {
+        let mut g = Graph::default();
+        self.net.forward(obs, &mut g).0
+    }
+}
+
+pub fn policy_gradient_loss(log_probs: &Tensor, advantages: &Tensor) -> f32 {
+    let n = log_probs.len();
+    let sum: f32 = log_probs
+        .data
+        .iter()
+        .zip(&advantages.data)
+        .map(|(&l, &a)| -l * a)
+        .sum();
+    sum / n as f32
+}
+
+pub fn value_loss(pred: &Tensor, targets: &Tensor) -> f32 {
+    let n = pred.len();
+    let sum: f32 = pred
+        .data
+        .iter()
+        .zip(&targets.data)
+        .map(|(&p, &t)| (p - t).powi(2))
+        .sum();
+    sum / n as f32
+}
+

--- a/crates/ml/tests/dense.rs
+++ b/crates/ml/tests/dense.rs
@@ -28,4 +28,25 @@ fn dense_bias_only() {
     assert!((y.data[1] + 0.5).abs() < 1e-6);
 }
 
+#[test]
+fn dense_xavier_init_stats() {
+    use rand::SeedableRng;
+    use rand::rngs::StdRng;
+
+    let mut rng = StdRng::seed_from_u64(42);
+    let dense = Dense::xavier(4, 3, &mut rng);
+    assert_eq!(dense.w.shape, vec![3, 4]);
+    assert_eq!(dense.b.shape, vec![3]);
+    assert_eq!(dense.w.data.len(), 12);
+    assert_eq!(dense.b.data.len(), 3);
+
+    let mean: f32 = dense.w.data.iter().copied().sum::<f32>() / dense.w.data.len() as f32;
+    assert!(mean.abs() < 0.1);
+    let var: f32 = dense.w.data.iter().map(|&x| (x - mean).powi(2)).sum::<f32>() / dense.w.data.len() as f32;
+    let limit = (6.0f32 / (4.0 + 3.0)).sqrt();
+    let expected_var = limit * limit / 3.0;
+    let rel_diff = (var - expected_var).abs() / expected_var;
+    assert!(rel_diff < 0.5);
+}
+
 

--- a/crates/ml/tests/tdd.rs
+++ b/crates/ml/tests/tdd.rs
@@ -1,0 +1,180 @@
+use ml::{Tensor, Dense, Graph, Relu, TanhAct, Sigmoid, Softmax, Sequential, Layer, Sgd, Adam, PolicyNetwork, ValueNetwork, policy_gradient_loss, value_loss};
+
+fn close(a: &[f32], b: &[f32]) -> bool {
+    a.iter().zip(b).all(|(x,y)| (*x - *y).abs() < 1e-5)
+}
+
+#[test]
+fn dense_backward_gradients() {
+    let w = vec![1.0, 2.0,
+                 -3.0, 0.5];
+    let b = vec![0.1, -0.2];
+    let x = Tensor::from_vec(vec![2], vec![0.5, -1.0]);
+    let dense = Dense::new(w.clone(), b.clone(), 2, 2);
+    let mut g = Graph::default();
+    let _y = dense.forward(&x, &mut g);
+    let grad_out = Tensor::from_vec(vec![2], vec![1.0, -2.0]);
+    let (dx, dw, db) = dense.backward(&x, &grad_out);
+    let expected_dx = vec![1.0*1.0 + -3.0*(-2.0), 2.0*1.0 + 0.5*(-2.0)];
+    let expected_dw = vec![0.5*1.0, -1.0*1.0,
+                           0.5*(-2.0), -1.0*(-2.0)];
+    assert!(close(&dx.data, &expected_dx));
+    assert!(close(&dw.data, &expected_dw));
+    assert!(close(&db.data, &grad_out.data));
+}
+
+#[test]
+fn relu_forward_backward() {
+    let x = Tensor::from_vec(vec![3], vec![-1.0, 0.0, 2.0]);
+    let relu = Relu::default();
+    let y = relu.forward(&x, &mut Graph::default());
+    assert_eq!(y.data, vec![0.0, 0.0, 2.0]);
+    let grad_out = Tensor::from_vec(vec![3], vec![0.1, 0.2, 0.3]);
+    let (dx, _) = relu.backward(&x, &grad_out);
+    assert_eq!(dx.data, vec![0.0, 0.0, 0.3]);
+}
+
+#[test]
+fn sigmoid_forward_backward() {
+    let x = Tensor::from_vec(vec![2], vec![0.0, 1.0]);
+    let sig = Sigmoid::default();
+    let y = sig.forward(&x, &mut Graph::default());
+    let expected = vec![0.5, 1.0 / (1.0 + (-1.0f32).exp())];
+    assert!(close(&y.data, &expected));
+    let grad_out = Tensor::from_vec(vec![2], vec![0.5, -0.5]);
+    let (dx, _) = sig.backward(&x, &grad_out);
+    let s0 = 0.5f32;
+    let s1 = expected[1];
+    let exp_dx = vec![0.5 * s0 * (1.0 - s0), -0.5 * s1 * (1.0 - s1)];
+    assert!(close(&dx.data, &exp_dx));
+}
+
+#[test]
+fn tanh_forward_backward() {
+    let x = Tensor::from_vec(vec![2], vec![0.0, 1.0]);
+    let t = TanhAct::default();
+    let y = t.forward(&x, &mut Graph::default());
+    let expected = vec![0.0f32.tanh(), 1.0f32.tanh()];
+    assert!(close(&y.data, &expected));
+    let grad_out = Tensor::from_vec(vec![2], vec![0.2, -0.1]);
+    let (dx, _) = t.backward(&x, &grad_out);
+    let exp_dx = vec![0.2 * (1.0 - expected[0].powi(2)), -0.1 * (1.0 - expected[1].powi(2))];
+    assert!(close(&dx.data, &exp_dx));
+}
+
+#[test]
+fn softmax_forward_backward() {
+    let x = Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]);
+    let sm = Softmax;
+    let y = sm.forward(&x, &mut Graph::default());
+    let exp_vals: Vec<f32> = vec![1.0f32.exp(), 2.0f32.exp(), 3.0f32.exp()];
+    let sum: f32 = exp_vals.iter().sum();
+    let expected: Vec<f32> = exp_vals.iter().map(|e| e / sum).collect();
+    assert!(close(&y.data, &expected));
+    let grad_out = Tensor::from_vec(vec![3], vec![0.1, -0.1, 0.0]);
+    let (dx, _) = sm.backward(&x, &grad_out);
+    // compute analytic gradient
+    let mut exp_dx = vec![0.0f32;3];
+    for i in 0..3 {
+        for j in 0..3 {
+            let delta = if i==j {1.0} else {0.0};
+            exp_dx[j] += grad_out.data[i] * expected[i] * (delta - expected[j]);
+        }
+    }
+    assert!(close(&dx.data, &exp_dx));
+}
+
+#[test]
+fn sequential_forward_backward() {
+    let mut seq = Sequential::new();
+    seq.push(Dense::new(vec![1.0], vec![0.0], 1, 1));
+    seq.push(Relu::default());
+    seq.push(Dense::new(vec![0.5], vec![0.0], 1, 1));
+    let x = Tensor::from_vec(vec![1], vec![2.0]);
+    let mut g = Graph::default();
+    let (out, activations) = seq.forward(&x, &mut g);
+    // manual
+    let h1: f32 = 1.0*2.0 + 0.0;
+    let h1a = h1.max(0.0);
+    let y = 0.5*h1a + 0.0;
+    assert!((out.data[0]-y).abs() < 1e-6);
+    let grad_out = Tensor::from_vec(vec![1], vec![1.0]);
+    let (dx, grads) = seq.backward(&activations, &grad_out);
+    // grads contains dw1, db1, dw2, db2 in reverse
+    assert_eq!(grads.len(), 4);
+    // verify final grad
+    let dw2 = vec![h1a*1.0];
+    let db2 = vec![1.0];
+    assert!(close(&grads[0].data, &dw2));
+    assert!(close(&grads[1].data, &db2));
+    // backward through relu and first dense
+    let relu_grad = if h1>0.0 {1.0} else {0.0};
+    let dw1 = vec![2.0 * 0.5 * relu_grad];
+    let db1 = vec![0.5 * relu_grad];
+    assert!(close(&grads[2].data, &dw1));
+    assert!(close(&grads[3].data, &db1));
+    assert!(close(&dx.data, &[0.5*relu_grad*1.0]));
+}
+
+#[test]
+fn sgd_update() {
+    let mut param = Tensor::from_vec(vec![2], vec![1.0, -1.0]);
+    let grad = Tensor::from_vec(vec![2], vec![0.5, -0.5]);
+    let mut opt = Sgd::new(0.1);
+    opt.step(&mut [(&mut param, &grad)]);
+    assert!(close(&param.data, &[0.95, -0.95]));
+}
+
+#[test]
+fn adam_update() {
+    let mut param = Tensor::from_vec(vec![1], vec![1.0]);
+    let grad = Tensor::from_vec(vec![1], vec![0.1]);
+    let mut opt = Adam::new(0.1);
+    opt.step(&mut [(&mut param, &grad)]);
+    // after first step of Adam with zero init moments
+    let m_hat: f32 = 0.1; // (1-beta1) * grad / (1-beta1)
+    let v_hat: f32 = 0.01; // (1-beta2) * grad^2 / (1-beta2)
+    let expected = 1.0 - 0.1 * m_hat / (v_hat.sqrt() + 1e-8f32);
+    assert!((param.data[0]-expected).abs() < 1e-6);
+}
+
+#[test]
+fn policy_network_output() {
+    let mut seq = Sequential::new();
+    seq.push(Dense::new(vec![0.5], vec![0.0], 1, 1));
+    seq.push(TanhAct::default());
+    let policy = PolicyNetwork::new(seq);
+    let x = Tensor::from_vec(vec![1], vec![2.0]);
+    let out = policy.act(&x);
+    assert_eq!(out.shape, vec![1]);
+    assert!(out.data[0] <= 1.0 && out.data[0] >= -1.0);
+}
+
+#[test]
+fn value_network_output() {
+    let mut seq = Sequential::new();
+    seq.push(Dense::new(vec![1.0], vec![0.0], 1, 1));
+    let value_net = ValueNetwork::new(seq);
+    let x = Tensor::from_vec(vec![1], vec![3.0]);
+    let out = value_net.value(&x);
+    assert_eq!(out.shape, vec![1]);
+}
+
+#[test]
+fn policy_gradient_loss_calc() {
+    let log_probs = Tensor::from_vec(vec![3], vec![-0.1, -0.2, -0.3]);
+    let adv = Tensor::from_vec(vec![3], vec![1.0, 0.5, -0.5]);
+    let loss = policy_gradient_loss(&log_probs, &adv);
+    let expected = (-(-0.1*1.0 + -0.2*0.5 + -0.3*-0.5))/3.0;
+    assert!((loss - expected).abs() < 1e-6);
+}
+
+#[test]
+fn value_loss_calc() {
+    let pred = Tensor::from_vec(vec![2], vec![1.0, 2.0]);
+    let target = Tensor::from_vec(vec![2], vec![1.5, 1.5]);
+    let loss = value_loss(&pred, &target);
+    let expected: f32 = ((1.0f32-1.5).powi(2) + (2.0f32-1.5).powi(2)) / 2.0;
+    assert!((loss - expected).abs() < 1e-6);
+}
+


### PR DESCRIPTION
## Summary
- expand `ml` crate with basic differentiable layer trait and helper structs
- add optimizer and network utilities with loss helpers
- provide extensive integration tests covering dense layers, activations, sequential models, optimizers, and RL-style networks

## Testing
- `cargo test --workspace --no-run`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684156e6274c8321ba25200cffd32da8