### PR TITLE
Add Cube shape and tests

### DIFF
--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -6,6 +6,9 @@ use compute::{ComputeBackend, ComputeError}; // BufferView and Kernel will be fu
 use std::sync::Arc;
 use std::mem::size_of; // Specific import for size_of
 
+mod shapes;
+pub use shapes::Cube;
+
 // --- Data Structures ---
 
 #[repr(C)]
@@ -65,6 +68,7 @@ impl From<ComputeError> for PhysicsError {
 
 pub struct PhysicsSim {
     pub spheres: Vec<Sphere>, // Host-side copy of sphere data
+    pub cubes: Vec<Cube>,
     pub params: PhysParams,
     backend: Arc<dyn ComputeBackend>, // Using Arc for flexibility, could be Box
                                       // The test calls sim.run() so sim needs to be mutable or run needs &mut self
@@ -94,6 +98,7 @@ impl PhysicsSim {
 
         Self {
             spheres,
+            cubes: Vec::new(),
             params,
             backend,
         }

--- a/crates/physics/src/shapes.rs
+++ b/crates/physics/src/shapes.rs
@@ -1,0 +1,41 @@
+use crate::Vec3;
+
+#[derive(Copy, Clone, Debug)]
+pub struct Cube {
+    pub side: f32,
+    pub mass: f32,
+}
+
+impl Cube {
+    #[must_use]
+    pub const fn new(side: f32, mass: f32) -> Self {
+        Self { side, mass }
+    }
+
+    /// Signed distance from point `p` to the cube centered at the origin.
+    #[must_use]
+    pub fn sdf(&self, p: Vec3) -> f32 {
+        let half = self.side * 0.5;
+        let qx = p.x.abs() - half;
+        let qy = p.y.abs() - half;
+        let qz = p.z.abs() - half;
+        let dx = qx.max(0.0);
+        let dy = qy.max(0.0);
+        let dz = qz.max(0.0);
+        let outside = (dx * dx + dy * dy + dz * dz).sqrt();
+        let inside = qx.max(qy.max(qz)).min(0.0);
+        outside + inside
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cube_sdf_at_center() {
+        let c = Cube::new(2.0, 1.0);
+        assert!((c.sdf(Vec3::new(0.0, 0.0, 0.0)) + 1.0).abs() < 1e-6);
+    }
+}
+

--- a/crates/physics/tests/cube.rs
+++ b/crates/physics/tests/cube.rs
@@ -1,0 +1,17 @@
+use physics::{Cube, Vec3};
+
+#[test]
+fn cube_creation() {
+    let c = Cube::new(2.0, 3.0);
+    assert_eq!(c.side, 2.0);
+    assert_eq!(c.mass, 3.0);
+}
+
+#[test]
+fn cube_sdf_basic() {
+    let cube = Cube::new(2.0, 1.0);
+    let eps = 1e-6f32;
+    assert!((cube.sdf(Vec3::new(0.0, 0.0, 0.0)) + 1.0).abs() < eps);
+    assert!(cube.sdf(Vec3::new(1.0, 0.0, 0.0)).abs() < eps);
+    assert!((cube.sdf(Vec3::new(2.0, 0.0, 0.0)) - 1.0).abs() < eps);
+}


### PR DESCRIPTION
## Summary
- implement `Cube` shape with signed distance function
- expose `Cube` from physics crate and track cubes in `PhysicsSim`
- add unit tests covering cube construction and sdf

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_68415ae2fb3483219f0a07659beb3ff0