### PR TITLE
Add CPU physics pipeline tests

### DIFF
--- a/crates/physics/Cargo.toml
+++ b/crates/physics/Cargo.toml
@@ -15,3 +15,7 @@ ml = { path = "../ml" }
 [[bench]]
 name = "physics"
 harness = false
+
+[[bench]]
+name = "scene"
+harness = false

--- a/crates/physics/benches/scene.rs
+++ b/crates/physics/benches/scene.rs
@@ -1,0 +1,27 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use physics::{PhysicsSim, Sphere, Vec3, Joint};
+
+fn bench_scene_run(c: &mut Criterion) {
+    c.bench_function("scene_run", |b| {
+        b.iter(|| {
+            let mut sim = PhysicsSim::new_single_sphere(1.0);
+            let num = 10u32;
+            for i in 1..num {
+                sim.spheres.push(Sphere {
+                    pos: Vec3::new(i as f32, 1.0, 0.0),
+                    vel: Vec3::new(0.0, 0.0, 0.0),
+                });
+                sim.joints.push(Joint {
+                    body_a: i - 1,
+                    body_b: i,
+                    rest_length: 1.0,
+                    _padding: 0,
+                });
+            }
+            sim.run(0.01, 10).unwrap();
+        })
+    });
+}
+
+criterion_group!(benches, bench_scene_run);
+criterion_main!(benches);

--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -3,8 +3,8 @@
 
 // Refined imports
 use compute::{ComputeBackend, ComputeError}; // BufferView and Kernel will be fully qualified
-use std::sync::Arc;
 use std::mem::size_of; // Specific import for size_of
+use std::sync::Arc;
 
 // --- Data Structures ---
 
@@ -40,6 +40,22 @@ pub struct PhysParams {
     pub force: [f32; 2],
 }
 
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct Joint {
+    pub body_a: u32,
+    pub body_b: u32,
+    pub rest_length: f32,
+    pub _padding: u32,
+}
+
+#[repr(C)]
+#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+pub struct JointParams {
+    pub compliance: f32,
+    pub _pad: [f32; 3],
+}
+
 // Structure to return from sim.run() to satisfy the test
 pub struct SphereState {
     pub pos: Vec3,
@@ -66,6 +82,8 @@ impl From<ComputeError> for PhysicsError {
 pub struct PhysicsSim {
     pub spheres: Vec<Sphere>, // Host-side copy of sphere data
     pub params: PhysParams,
+    pub joints: Vec<Joint>,
+    pub joint_params: JointParams,
     backend: Arc<dyn ComputeBackend>, // Using Arc for flexibility, could be Box
                                       // The test calls sim.run() so sim needs to be mutable or run needs &mut self
                                       // If run is &mut self, then backend doesn't strictly need Arc unless sim is cloned
@@ -95,6 +113,8 @@ impl PhysicsSim {
         Self {
             spheres,
             params,
+            joints: Vec::new(),
+            joint_params: JointParams { compliance: 0.0, _pad: [0.0; 3] },
             backend,
         }
     }
@@ -103,50 +123,193 @@ impl PhysicsSim {
         if self.spheres.is_empty() {
             return Ok(());
         }
-
         let sphere_bytes_arc: Arc<[u8]> = bytemuck::cast_slice(&self.spheres).to_vec().into();
         let sphere_buffer_view = compute::BufferView::new(
-            sphere_bytes_arc, // Pass the Arc directly
+            sphere_bytes_arc.clone(),
             vec![self.spheres.len()],
             size_of::<Sphere>(),
         );
 
         let params_bytes_arc: Arc<[u8]> = bytemuck::bytes_of(&self.params).to_vec().into();
-        let params_buffer_view = compute::BufferView::new(
-            params_bytes_arc, // Pass the Arc directly
-            vec![1],
-            size_of::<PhysParams>(),
-        );
+        let params_buffer_view = compute::BufferView::new(params_bytes_arc, vec![1], size_of::<PhysParams>());
 
         let num_spheres = self.spheres.len() as u32;
         let workgroups_x = (num_spheres + WORKGROUP_SIZE - 1) / WORKGROUP_SIZE;
 
-        // Dispatch Kernel::IntegrateBodies (placeholder)
-        // The actual data handling (read-back) will depend on the kernel's implementation.
-        let _result_buffers = self.backend.dispatch(
-            &compute::Kernel::IntegrateBodies, // Changed from SphereStep
-            &[sphere_buffer_view, params_buffer_view], // Assuming IntegrateBodies takes similar initial buffers
+        let result_buffers = self.backend.dispatch(
+            &compute::Kernel::IntegrateBodies,
+            &[sphere_buffer_view.clone(), params_buffer_view],
             [workgroups_x, 1, 1],
         )?;
 
-        // Manual CPU-side integration logic REMOVED.
-        // This logic should eventually be part of the IntegrateBodies kernel's
-        // CPU implementation (in MockCpu) or its WGSL shader.
+        if let Some(updated) = result_buffers.get(0) {
+            if updated.len() == self.spheres.len() * size_of::<Sphere>() {
+                let new_spheres: Vec<Sphere> = updated
+                    .chunks_exact(size_of::<Sphere>())
+                    .map(bytemuck::pod_read_unaligned)
+                    .collect();
+                self.spheres.clone_from_slice(&new_spheres);
+            }
+        }
 
-        // For now, we might want to update self.spheres from _result_buffers if the
-        // IntegrateBodies kernel (even the mock one) is designed to return the updated sphere data.
-        // Example (if first buffer out is spheres):
-        // if let Some(updated_sphere_data) = _result_buffers.get(0) {
-        //     if updated_sphere_data.len() == self.spheres.len() * size_of::<Sphere>() {
-        //         let updated_spheres: &[Sphere] = bytemuck::cast_slice(updated_sphere_data);
-        //         self.spheres.clone_from_slice(updated_spheres);
-        //     } else {
-        //        // Potentially log an error or handle mismatch
-        //     }
-        // }
+        // --- Detect contacts against simple ground plane ---
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct SdfVec3 {
+            x: f32,
+            y: f32,
+            z: f32,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct SdfBody {
+            pos: SdfVec3,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct SdfPlane {
+            height: f32,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct SdfContact {
+            index: u32,
+            penetration: f32,
+        }
 
+        let bodies: Vec<SdfBody> = self
+            .spheres
+            .iter()
+            .map(|s| SdfBody {
+                pos: SdfVec3 {
+                    x: s.pos.x,
+                    y: s.pos.y,
+                    z: s.pos.z,
+                },
+            })
+            .collect();
 
-        // self.params.force = [0.0, 0.0]; // This might still be relevant depending on how forces are handled
+        let bodies_bytes: Arc<[u8]> = bytemuck::cast_slice(&bodies).to_vec().into();
+        let bodies_view = compute::BufferView::new(bodies_bytes, vec![bodies.len()], size_of::<SdfBody>());
+
+        let plane = SdfPlane { height: 0.0 };
+        let plane_bytes: Arc<[u8]> = bytemuck::bytes_of(&plane).to_vec().into();
+        let plane_view = compute::BufferView::new(plane_bytes, vec![1], size_of::<SdfPlane>());
+
+        let placeholder: Arc<[u8]> = vec![0u8; bodies.len() * size_of::<SdfContact>()].into();
+        let contacts_view = compute::BufferView::new(placeholder, vec![bodies.len()], size_of::<SdfContact>());
+
+        let contact_buffers = self.backend.dispatch(
+            &compute::Kernel::DetectContactsSDF,
+            &[bodies_view, plane_view, contacts_view],
+            [1, 1, 1],
+        )?;
+
+        let contacts: Vec<SdfContact> = if let Some(bytes) = contact_buffers.get(0) {
+            bytes
+                .chunks_exact(size_of::<SdfContact>())
+                .map(bytemuck::pod_read_unaligned)
+                .collect()
+        } else {
+            Vec::new()
+        };
+
+        // --- Solve contacts ---
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct PbdContact {
+            body_index: u32,
+            normal: SdfVec3,
+            depth: f32,
+        }
+
+        let contacts_pbd: Vec<PbdContact> = contacts
+            .iter()
+            .map(|c| PbdContact {
+                body_index: c.index,
+                normal: SdfVec3 { x: 0.0, y: 1.0, z: 0.0 },
+                depth: c.penetration,
+            })
+            .collect();
+
+        let contacts_bytes: Arc<[u8]> = bytemuck::cast_slice(&contacts_pbd).to_vec().into();
+        let contacts_view = compute::BufferView::new(contacts_bytes, vec![contacts_pbd.len()], size_of::<PbdContact>());
+
+        let sphere_bytes_arc: Arc<[u8]> = bytemuck::cast_slice(&self.spheres).to_vec().into();
+        let spheres_view = compute::BufferView::new(sphere_bytes_arc.clone(), vec![self.spheres.len()], size_of::<Sphere>());
+        let params_placeholder: Arc<[u8]> = vec![0u8; 4].into();
+        let params_view = compute::BufferView::new(params_placeholder, vec![1], 4);
+
+        let solved = self.backend.dispatch(
+            &compute::Kernel::SolveContactsPBD,
+            &[spheres_view, contacts_view, params_view],
+            [1, 1, 1],
+        )?;
+
+        if let Some(bytes) = solved.get(0) {
+            if bytes.len() == self.spheres.len() * size_of::<Sphere>() {
+                let updated: Vec<Sphere> = bytes
+                    .chunks_exact(size_of::<Sphere>())
+                    .map(bytemuck::pod_read_unaligned)
+                    .collect();
+                self.spheres.clone_from_slice(&updated);
+            }
+        }
+
+        // --- Solve joints ---
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct JointVec3 {
+            x: f32,
+            y: f32,
+            z: f32,
+        }
+        #[repr(C)]
+        #[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+        struct JointBody {
+            pos: JointVec3,
+        }
+
+        let joint_bodies: Vec<JointBody> = self
+            .spheres
+            .iter()
+            .map(|s| JointBody {
+                pos: JointVec3 {
+                    x: s.pos.x,
+                    y: s.pos.y,
+                    z: s.pos.z,
+                },
+            })
+            .collect();
+
+        let body_bytes: Arc<[u8]> = bytemuck::cast_slice(&joint_bodies).to_vec().into();
+        let body_view = compute::BufferView::new(body_bytes, vec![joint_bodies.len()], size_of::<JointBody>());
+
+        let joint_bytes: Arc<[u8]> = bytemuck::cast_slice(&self.joints).to_vec().into();
+        let joint_view = compute::BufferView::new(joint_bytes, vec![self.joints.len()], size_of::<Joint>());
+
+        let joint_param_bytes: Arc<[u8]> = bytemuck::bytes_of(&self.joint_params).to_vec().into();
+        let joint_param_view = compute::BufferView::new(joint_param_bytes, vec![1], size_of::<JointParams>());
+
+        let solved = self.backend.dispatch(
+            &compute::Kernel::SolveJointsPBD,
+            &[body_view, joint_view, joint_param_view],
+            [1, 1, 1],
+        )?;
+
+        if let Some(bytes) = solved.get(0) {
+            if bytes.len() == self.spheres.len() * size_of::<JointBody>() {
+                let updated: Vec<JointBody> = bytes
+                    .chunks_exact(size_of::<JointBody>())
+                    .map(bytemuck::pod_read_unaligned)
+                    .collect();
+                for (sphere, upd) in self.spheres.iter_mut().zip(updated) {
+                    sphere.pos.x = upd.pos.x;
+                    sphere.pos.y = upd.pos.y;
+                    sphere.pos.z = upd.pos.z;
+                }
+            }
+        }
 
         Ok(())
     }

--- a/tests/collision.rs
+++ b/tests/collision.rs
@@ -1,0 +1,9 @@
+use physics::{PhysicsSim, Vec3};
+
+#[test]
+fn sphere_resolves_floor_contact() {
+    let mut sim = PhysicsSim::new_single_sphere(-0.1);
+    // One step with small dt
+    let _ = sim.run(0.01, 1).unwrap();
+    assert!(sim.spheres[0].pos.y >= 0.0);
+}

--- a/tests/joint.rs
+++ b/tests/joint.rs
@@ -1,0 +1,14 @@
+use physics::{PhysicsSim, Sphere, Vec3, Joint};
+
+#[test]
+fn distance_joint_moves_bodies_toward_rest_length() {
+    let mut sim = PhysicsSim::new_single_sphere(0.0);
+    sim.spheres.push(Sphere { pos: Vec3::new(1.5, 0.0, 0.0), vel: Vec3::new(0.0, 0.0, 0.0) });
+    sim.joints.push(Joint { body_a: 0, body_b: 1, rest_length: 1.0, _padding: 0 });
+    let _ = sim.run(0.0, 1).unwrap();
+    let dx = sim.spheres[1].pos.x - sim.spheres[0].pos.x;
+    let dy = sim.spheres[1].pos.y - sim.spheres[0].pos.y;
+    let dz = sim.spheres[1].pos.z - sim.spheres[0].pos.z;
+    let dist = (dx*dx + dy*dy + dz*dz).sqrt();
+    assert!((dist - 1.0).abs() < 1e-5);
+}

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -1,0 +1,34 @@
+use physics::{PhysicsSim, Sphere, Vec3, Joint};
+
+#[test]
+fn chain_of_spheres_runs_stably() {
+    let mut sim = PhysicsSim::new_single_sphere(1.0);
+    let num = 10u32;
+    for i in 1..num {
+        sim.spheres.push(Sphere {
+            pos: Vec3::new(i as f32, 1.0, 0.0),
+            vel: Vec3::new(0.0, 0.0, 0.0),
+        });
+        sim.joints.push(Joint {
+            body_a: i - 1,
+            body_b: i,
+            rest_length: 1.0,
+            _padding: 0,
+        });
+    }
+
+    let _ = sim.run(0.01, 10).unwrap();
+
+    for s in &sim.spheres {
+        assert!(s.pos.y >= 0.0);
+    }
+
+    // Check chain length approximately maintained
+    let start = sim.spheres.first().unwrap().pos;
+    let end = sim.spheres.last().unwrap().pos;
+    let dx = end.x - start.x;
+    let dy = end.y - start.y;
+    let dz = end.z - start.z;
+    let dist = (dx * dx + dy * dy + dz * dz).sqrt();
+    assert!((dist - ((num - 1) as f32)).abs() < 0.5);
+}


### PR DESCRIPTION
## Summary
- dispatch DetectContactsSDF, SolveContactsPBD and SolveJointsPBD in `PhysicsSim::step_gpu`
- support simple joints
- test collision resolution and joint solving
- add chain-of-spheres scene test
- benchmark the scene

## Testing
- `cargo test --quiet`
- `cargo bench --bench scene --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6841d2e631b08321bf5390d0829fea41