### PR TITLE
Refactor runtime entrypoint

### DIFF
--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1,0 +1,72 @@
+use anyhow::Result;
+use physics::PhysicsSim;
+
+#[cfg(feature = "render")]
+use render::Renderer;
+
+use crate::watcher;
+
+pub fn run(enable_render: bool) -> Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let _shader_watcher = match watcher::start() {
+        Ok(watcher_instance) => {
+            tracing::info!("Shader watcher started successfully.");
+            Some(watcher_instance)
+        }
+        Err(e) => {
+            tracing::error!("Failed to start shader watcher: {e:?}");
+            None
+        }
+    };
+
+    #[cfg(feature = "render")]
+    let mut renderer = if enable_render {
+        Some(Renderer::new()?)
+    } else {
+        None
+    };
+
+    tracing::info!("Initializing physics simulation...");
+    let mut sim = PhysicsSim::new_single_sphere(10.0);
+    let dt = 0.01_f32;
+    let num_steps = 200;
+
+    tracing::info!(
+        "Starting simulation loop for {} steps with dt = {}...",
+        num_steps,
+        dt
+    );
+    for i in 0..num_steps {
+        if let Err(e) = sim.run(dt, 1) {
+            tracing::error!("Error during simulation step {}: {:?}", i, e);
+            break;
+        }
+        #[cfg(feature = "render")]
+        if let Some(r) = renderer.as_mut() {
+            r.update_spheres(&sim.spheres);
+            r.render()?;
+        }
+        if (i + 1) % 50 == 0 {
+            if !sim.spheres.is_empty() {
+                tracing::info!(
+                    "Simulation step {} complete. Sphere_y: {}",
+                    i + 1,
+                    sim.spheres[0].pos.y
+                );
+            } else {
+                tracing::info!(
+                    "Simulation step {} complete. No spheres to report position.",
+                    i + 1
+                );
+            }
+        }
+    }
+
+    tracing::info!("Simulation loop finished after {} steps.", num_steps);
+    if !sim.spheres.is_empty() {
+        tracing::info!("Final sphere position: {:?}", sim.spheres[0].pos);
+    }
+
+    Ok(())
+}

--- a/crates/runtime/src/main.rs
+++ b/crates/runtime/src/main.rs
@@ -1,77 +1,12 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(clippy::unnecessary_wraps)]
 
+mod app;
 mod watcher;
 
 use anyhow::Result;
-use physics::PhysicsSim;
-
-#[cfg(feature = "render")]
-use render::Renderer;
 
 fn main() -> Result<()> {
-    tracing_subscriber::fmt::init();
-
-    let _shader_watcher = match watcher::start() {
-        Ok(watcher_instance) => {
-            tracing::info!("Shader watcher started successfully.");
-            Some(watcher_instance)
-        }
-        Err(e) => {
-            tracing::error!("Failed to start shader watcher: {e:?}");
-            None
-        }
-    };
-
     let enable_render = std::env::args().any(|a| a == "--draw");
-
-    #[cfg(feature = "render")]
-    let mut renderer = if enable_render {
-        Some(Renderer::new()?)
-    } else {
-        None
-    };
-
-    tracing::info!("Initializing physics simulation...");
-    let mut sim = PhysicsSim::new_single_sphere(10.0);
-    let dt = 0.01_f32;
-    let num_steps = 200;
-
-    tracing::info!(
-        "Starting simulation loop for {} steps with dt = {}...",
-        num_steps,
-        dt
-    );
-    for i in 0..num_steps {
-        if let Err(e) = sim.run(dt, 1) {
-            tracing::error!("Error during simulation step {}: {:?}", i, e);
-            break;
-        }
-        #[cfg(feature = "render")]
-        if let Some(r) = renderer.as_mut() {
-            r.update_spheres(&sim.spheres);
-            r.render()?;
-        }
-        if (i + 1) % 50 == 0 {
-            if !sim.spheres.is_empty() {
-                tracing::info!(
-                    "Simulation step {} complete. Sphere_y: {}",
-                    i + 1,
-                    sim.spheres[0].pos.y
-                );
-            } else {
-                tracing::info!(
-                    "Simulation step {} complete. No spheres to report position.",
-                    i + 1
-                );
-            }
-        }
-    }
-
-    tracing::info!("Simulation loop finished after {} steps.", num_steps);
-    if !sim.spheres.is_empty() {
-        tracing::info!("Final sphere position: {:?}", sim.spheres[0].pos);
-    }
-
-    Ok(())
+    app::run(enable_render)
 }


### PR DESCRIPTION
## Summary
- move simulation logic into `app::run`
- keep shader watcher in its own module
- let `main` only parse CLI args and call into `app`

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6842b1af01f083218c50e6aaac526d8c