### PR TITLE
Fix warnings, add test commands

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,5 +11,3 @@ resolver = "2"
 [workspace.dependencies]
 naga = { version = "0.19", features = ["wgsl-in"] }
 
-[workspace.dev-dependencies]
-criterion = "0.5" 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,33 @@ cargo test
 
 Unit tests cover the CPU compute backend, physics stepping, shader compilation and a simple integration test verifying that a falling sphere matches analytic physics. More GPU‑specific tests will be added as the WebGPU backend matures.
 
+## Command Cheatsheet
+
+Below is a quick reference of commands for running the various test suites and examples. All commands assume you are at the repository root.
+
+```bash
+# Run the entire test suite (CPU fallback backend)
+cargo test
+
+# Run only compute crate tests
+cargo test -p compute
+
+# Run physics crate tests
+cargo test -p physics
+
+# Execute integration tests under `tests/`
+cargo test --test free_fall
+
+# Compile and run GPU kernels on macOS with Metal
+cargo test -p compute --features metal
+
+# Compile benches (requires `criterion`)
+cargo bench
+
+# Launch the renderer example
+cargo run -p runtime --features render -- --draw
+```
+
 ## Visualizing the simulation
 
 The project includes a minimal renderer based on `wgpu`. To see a live sphere

--- a/crates/render/src/renderer.rs
+++ b/crates/render/src/renderer.rs
@@ -9,11 +9,11 @@ use winit::platform::pump_events::{EventLoopExtPumpEvents, PumpStatus};
 
 pub struct Renderer<'w> {
     event_loop: EventLoop<()>,
-    window: winit::window::Window,
+    _window: winit::window::Window,
     surface: wgpu::Surface<'w>,
     device: wgpu::Device,
     queue: wgpu::Queue,
-    config: wgpu::SurfaceConfiguration,
+    _config: wgpu::SurfaceConfiguration,
     pipeline: wgpu::RenderPipeline,
     vertex_buffer: wgpu::Buffer,
     vertices: Vec<[f32; 2]>,
@@ -117,11 +117,11 @@ impl<'w> Renderer<'w> {
 
         Ok(Renderer {
             event_loop,
-            window,
+            _window: window,
             surface,
             device,
             queue,
-            config,
+            _config: config,
             pipeline,
             vertex_buffer,
             vertices,

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -6,7 +6,7 @@ use render::Renderer;
 
 use crate::watcher;
 
-pub fn run(enable_render: bool) -> Result<()> {
+pub fn run(_enable_render: bool) -> Result<()> {
     tracing_subscriber::fmt::init();
 
     let _shader_watcher = match watcher::start() {
@@ -21,7 +21,7 @@ pub fn run(enable_render: bool) -> Result<()> {
     };
 
     #[cfg(feature = "render")]
-    let mut renderer = if enable_render {
+    let mut renderer = if _enable_render {
         Some(Renderer::new()?)
     } else {
         None


### PR DESCRIPTION
## Summary
- silence render and runtime warnings
- remove unused workspace dev-deps
- document common commands in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68456ab82b5483219f575c940d467c22