### PR TITLE
Fix compute tests by enabling mock backend

### DIFF
--- a/crates/compute/Cargo.toml
+++ b/crates/compute/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [features]
+default = ["mock"]
 mock = []
 metal = ["dep:wgpu"]
 


### PR DESCRIPTION
## Summary
- enable the CPU mock backend by default for the `compute` crate

## Testing
- `cargo test -p compute`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68456e445dac8321a716a6cae13a3ed1