### PR TITLE
Support per-body forces in physics

### DIFF
--- a/crates/compute/src/backend/mock_cpu.rs
+++ b/crates/compute/src/backend/mock_cpu.rs
@@ -247,7 +247,7 @@ mod tests {
         assert_eq!(binding_count(&Kernel::MatMul), 4);
 
         // Physics world passes
-        assert_eq!(binding_count(&Kernel::IntegrateBodies), 2);
+        assert_eq!(binding_count(&Kernel::IntegrateBodies), 3);
         assert_eq!(binding_count(&Kernel::DetectContactsSphere), 2);
         assert_eq!(binding_count(&Kernel::DetectContactsBox), 3);
         assert_eq!(binding_count(&Kernel::DetectContactsSDF), 3);

--- a/crates/compute/src/layout.rs
+++ b/crates/compute/src/layout.rs
@@ -41,7 +41,7 @@ pub const fn binding_count(kernel: &crate::Kernel) -> u32 {
         crate::Kernel::MatMul => 4, // IN_A, IN_B, OUT, CONFIG
 
         // Physics world passes
-        crate::Kernel::IntegrateBodies => 2, // BODIES_INOUT, PARAMS_UNIFORM
+        crate::Kernel::IntegrateBodies => 3, // BODIES_INOUT, PARAMS_UNIFORM, FORCES_IN
         crate::Kernel::DetectContactsSphere => 2, // BODIES_IN, CONTACTS_OUT
         crate::Kernel::DetectContactsBox => 3, // BODIES_IN, BOX_IN, CONTACTS_OUT
         crate::Kernel::DetectContactsSDF => 3, // BODIES_IN, SDF_DATA_UNIFORM_OR_STORAGE, CONTACTS_OUT

--- a/crates/physics/benches/scene.rs
+++ b/crates/physics/benches/scene.rs
@@ -11,6 +11,7 @@ fn bench_scene_run(c: &mut Criterion) {
                     pos: Vec3::new(i as f32, 1.0, 0.0),
                     vel: Vec3::new(0.0, 0.0, 0.0),
                 });
+                sim.params.forces.push([0.0, 0.0]);
                 sim.joints.push(Joint {
                     body_a: i - 1,
                     body_b: i,

--- a/crates/physics/src/types.rs
+++ b/crates/physics/src/types.rs
@@ -27,12 +27,12 @@ pub struct BoxShape {
     pub half_extents: Vec3,
 }
 
-#[repr(C)]
-#[derive(Copy, Clone, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+#[derive(Clone, Debug)]
 pub struct PhysParams {
     pub gravity: Vec3,
     pub dt: f32,
-    pub force: [f32; 2],
+    /// External forces applied per sphere (x/y components). Length must match number of spheres.
+    pub forces: Vec<[f32; 2]>,
 }
 
 #[repr(C)]

--- a/shaders/integrate_euler.wgsl
+++ b/shaders/integrate_euler.wgsl
@@ -5,7 +5,7 @@ struct Sphere {
 
 @group(0) @binding(0) var<storage, read_write> spheres : array<Sphere>;
 @group(0) @binding(1) var<uniform>            params  : vec4<f32>; // xyz: gravity, w: dt
-@group(0) @binding(2) var<uniform>            force   : vec2<f32>;
+@group(0) @binding(2) var<storage, read>      forces  : array<vec2<f32>>;
 
 @compute @workgroup_size(256)
 fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
@@ -15,7 +15,7 @@ fn main(@builtin(global_invocation_id) gid : vec3<u32>) {
   var s = spheres[idx];
   let dt = params.w;
   let g = params.xyz;
-  let f = vec3<f32>(force, 0.0);
+  let f = vec3<f32>(forces[idx], 0.0);
   let acc = g + f;
   s.pos += s.vel * dt + 0.5 * acc * dt * dt;
   s.vel += acc * dt;

--- a/tests/collision.rs
+++ b/tests/collision.rs
@@ -15,6 +15,7 @@ fn two_spheres_collide_in_free_fall() {
     let mut sim = PhysicsSim::new_single_sphere(5.0);
     sim.spheres[0].vel = Vec3::new(0.0, -2.0, 0.0);
     sim.spheres.push(Sphere { pos: Vec3::new(0.0, 2.0, 0.0), vel: Vec3::new(0.0, 0.0, 0.0) });
+    sim.params.forces.push([0.0, 0.0]);
 
     let _ = sim.run(0.01, 51).unwrap();
 

--- a/tests/forces.rs
+++ b/tests/forces.rs
@@ -1,0 +1,17 @@
+use physics::{PhysicsSim, Sphere, Vec3};
+
+#[test]
+fn per_body_forces_move_spheres_independently() {
+    let mut sim = PhysicsSim::new_single_sphere(0.0);
+    sim.params.gravity = Vec3::new(0.0, 0.0, 0.0);
+    sim.spheres.push(Sphere { pos: Vec3::new(0.0, 0.0, 0.0), vel: Vec3::new(0.0, 0.0, 0.0) });
+    sim.params.forces.push([ -1.0, 0.0 ]);
+    sim.params.forces[0] = [1.0, 0.0];
+
+    let _ = sim.run(0.1, 1).unwrap();
+
+    let pos0 = sim.spheres[0].pos.x;
+    let pos1 = sim.spheres[1].pos.x;
+    assert!(pos0 > 0.0);
+    assert!(pos1 < 0.0);
+}

--- a/tests/joint.rs
+++ b/tests/joint.rs
@@ -4,6 +4,7 @@ use physics::{PhysicsSim, Sphere, Vec3, Joint};
 fn distance_joint_moves_bodies_toward_rest_length() {
     let mut sim = PhysicsSim::new_single_sphere(0.0);
     sim.spheres.push(Sphere { pos: Vec3::new(1.5, 0.0, 0.0), vel: Vec3::new(0.0, 0.0, 0.0) });
+    sim.params.forces.push([0.0, 0.0]);
     sim.joints.push(Joint { body_a: 0, body_b: 1, rest_length: 1.0, _padding: 0 });
     let _ = sim.run(0.0, 1).unwrap();
     let dx = sim.spheres[1].pos.x - sim.spheres[0].pos.x;

--- a/tests/scene.rs
+++ b/tests/scene.rs
@@ -9,6 +9,7 @@ fn chain_of_spheres_runs_stably() {
             pos: Vec3::new(i as f32, 1.0, 0.0),
             vel: Vec3::new(0.0, 0.0, 0.0),
         });
+        sim.params.forces.push([0.0, 0.0]);
         sim.joints.push(Joint {
             body_a: i - 1,
             body_b: i,


### PR DESCRIPTION
## Summary
- add `forces` vector to `PhysParams`
- pass forces to `IntegrateBodies` and update kernel implementation
- update WGSL shader to read per-body forces
- adjust physics benches and tests for new parameter
- add new test verifying distinct forces move spheres separately

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684576e5e03c8321a4ab04ad84841e71