### PR TITLE
Implement Graph execution using compute backend

### DIFF
--- a/crates/ml/src/graph.rs
+++ b/crates/ml/src/graph.rs
@@ -1,8 +1,7 @@
 use crate::recorder::Recorder;
 use crate::tensor::Tensor;
-use compute::{ComputeBackend, ComputeError};
+use compute::ComputeError;
 use std::collections::HashMap;
-use std::sync::Arc;
 
 /// An enumeration of the possible operations in a computation graph.
 #[derive(Clone, Copy, Debug)]
@@ -49,9 +48,141 @@ impl Graph {
     pub fn new() -> Self {
         Self { nodes: Vec::new() }
     }
-    /// Executes the computation graph on a given backend.
-    /// Note: This is a placeholder and does not yet support GPU execution.
-    pub fn run(&self, _backend: &Arc<dyn ComputeBackend>) -> Result<(), ComputeError> {
+    /// Executes the computation graph using the [`compute`] backend.
+    ///
+    /// The tensors for each recorded node must be provided via `tensors`.
+    /// Results are written back into the output tensors contained in `tensors`.
+    pub fn run(&self, tensors: &mut HashMap<usize, Tensor>) -> Result<(), ComputeError> {
+        use compute::{BufferView, Kernel};
+
+        let backend = compute::default_backend();
+
+        for node in &self.nodes {
+            let kernel = match node.op {
+                EOp::Add => Kernel::Add,
+                EOp::Mul => Kernel::Mul,
+                EOp::ReduceSum => Kernel::ReduceSum,
+                // Unsupported ops map to available kernels when possible
+                EOp::MatMul => Kernel::MatMul,
+                EOp::Tanh => Kernel::Tanh,
+                EOp::Sub => Kernel::Sub,
+                EOp::Clamp => Kernel::Clamp,
+                EOp::Min => Kernel::Min,
+                EOp::ReduceMean => Kernel::ReduceMean,
+                EOp::Exp => Kernel::Exp,
+                _ => return Err(ComputeError::BackendUnavailable),
+            };
+
+            let a = tensors.get(&node.a).expect("tensor a missing");
+            let a_view = BufferView::new(
+                bytemuck::cast_slice(&a.data).to_vec().into(),
+                a.shape.clone(),
+                std::mem::size_of::<f32>(),
+            );
+
+            let mut binds: Vec<BufferView> = Vec::new();
+            binds.push(a_view);
+
+            match node.op {
+                EOp::Add | EOp::Mul | EOp::Sub | EOp::Min => {
+                    let b = tensors.get(&node.b).expect("tensor b missing");
+                    let b_view = BufferView::new(
+                        bytemuck::cast_slice(&b.data).to_vec().into(),
+                        b.shape.clone(),
+                        std::mem::size_of::<f32>(),
+                    );
+                    binds.push(b_view);
+
+                    let out = tensors.get(&node.out).expect("output tensor missing");
+                    let out_placeholder = BufferView::new(
+                        vec![0u8; out.data.len() * std::mem::size_of::<f32>()].into(),
+                        out.shape.clone(),
+                        std::mem::size_of::<f32>(),
+                    );
+                    binds.push(out_placeholder);
+
+                    // simple config buffer
+                    let cfg = BufferView::new(vec![0u8; 4].into(), vec![1], 4);
+                    binds.push(cfg);
+
+                    let result = backend.dispatch(&kernel, &binds, [1, 1, 1])?;
+                    let out_tensor = tensors.get_mut(&node.out).expect("output tensor missing");
+                    out_tensor.data = bytemuck::cast_slice(&result[0]).to_vec();
+                }
+                EOp::ReduceSum | EOp::ReduceMean => {
+                    let out = tensors.get(&node.out).expect("output tensor missing");
+                    let out_placeholder = BufferView::new(
+                        vec![0u8; std::mem::size_of::<f32>()].into(),
+                        vec![1],
+                        std::mem::size_of::<f32>(),
+                    );
+                    binds.push(out_placeholder);
+                    let cfg = BufferView::new(vec![0u8; 4].into(), vec![1], 4);
+                    binds.push(cfg);
+
+                    let result = backend.dispatch(&kernel, &binds, [1, 1, 1])?;
+                    let out_tensor = tensors.get_mut(&node.out).expect("output tensor missing");
+                    out_tensor.data = vec![*bytemuck::from_bytes(&result[0])];
+                }
+                EOp::MatMul => {
+                    let b = tensors.get(&node.b).expect("tensor b missing");
+                    let b_view = BufferView::new(
+                        bytemuck::cast_slice(&b.data).to_vec().into(),
+                        b.shape.clone(),
+                        std::mem::size_of::<f32>(),
+                    );
+                    binds.push(b_view);
+
+                    let out = tensors.get(&node.out).expect("output tensor missing");
+                    let out_placeholder = BufferView::new(
+                        vec![0u8; out.data.len() * std::mem::size_of::<f32>()].into(),
+                        out.shape.clone(),
+                        std::mem::size_of::<f32>(),
+                    );
+                    binds.push(out_placeholder);
+
+                    #[repr(C)]
+                    #[derive(Clone, Copy, Debug, bytemuck::Pod, bytemuck::Zeroable)]
+                    struct MatMulConfig {
+                        m: u32,
+                        k: u32,
+                        n: u32,
+                    }
+
+                    let m = a.shape[0] as u32;
+                    let k = a.shape[1] as u32;
+                    let n = b.shape[0] as u32;
+                    let cfg_struct = MatMulConfig { m, k, n };
+                    let cfg = BufferView::new(
+                        bytemuck::bytes_of(&cfg_struct).to_vec().into(),
+                        vec![1],
+                        std::mem::size_of::<MatMulConfig>(),
+                    );
+                    binds.push(cfg);
+
+                    let result = backend.dispatch(&kernel, &binds, [1, 1, 1])?;
+                    let out_tensor = tensors.get_mut(&node.out).expect("output tensor missing");
+                    out_tensor.data = bytemuck::cast_slice(&result[0]).to_vec();
+                }
+                EOp::Tanh | EOp::Exp | EOp::Clamp => {
+                    let out = tensors.get(&node.out).expect("output tensor missing");
+                    let out_placeholder = BufferView::new(
+                        vec![0u8; out.data.len() * std::mem::size_of::<f32>()].into(),
+                        out.shape.clone(),
+                        std::mem::size_of::<f32>(),
+                    );
+                    binds.push(out_placeholder);
+                    let cfg = BufferView::new(vec![0u8; 4].into(), vec![1], 4);
+                    binds.push(cfg);
+
+                    let result = backend.dispatch(&kernel, &binds, [1, 1, 1])?;
+                    let out_tensor = tensors.get_mut(&node.out).expect("output tensor missing");
+                    out_tensor.data = bytemuck::cast_slice(&result[0]).to_vec();
+                }
+                _ => {}
+            }
+        }
+
         Ok(())
     }
 }

--- a/crates/ml/tests/06_graph_run.rs
+++ b/crates/ml/tests/06_graph_run.rs
@@ -1,0 +1,32 @@
+use ml::graph::Graph;
+use ml::Tensor;
+use std::collections::HashMap;
+
+#[test]
+fn graph_run_matches_cpu() {
+    let mut g = Graph::new();
+    let mut tensors = HashMap::new();
+
+    let a = Tensor::from_vec(vec![3], vec![1.0, 2.0, 3.0]);
+    let b = Tensor::from_vec(vec![3], vec![4.0, 5.0, 6.0]);
+    tensors.insert(a.id, a.clone());
+    tensors.insert(b.id, b.clone());
+
+    let c = a.add(&b, &mut g, &mut tensors);
+    let d = c.mul(&b, &mut g, &mut tensors);
+    let e = d.reduce_sum(&mut g, &mut tensors);
+
+    let expected_c = c.data.clone();
+    let expected_d = d.data.clone();
+    let expected_e = e.data.clone();
+
+    tensors.get_mut(&c.id).unwrap().data.fill(0.0);
+    tensors.get_mut(&d.id).unwrap().data.fill(0.0);
+    tensors.get_mut(&e.id).unwrap().data.fill(0.0);
+
+    g.run(&mut tensors).unwrap();
+
+    assert_eq!(tensors.get(&c.id).unwrap().data, expected_c);
+    assert_eq!(tensors.get(&d.id).unwrap().data, expected_d);
+    assert_eq!(tensors.get(&e.id).unwrap().data, expected_e);
+}


### PR DESCRIPTION
## Summary
- implement `Graph::run` to execute recorded ops with compute backend
- create new test verifying `Graph::run` for a simple Add→Mul→ReduceSum graph

## Testing
- `cargo test --workspace --tests`

------
https://chatgpt.com/codex/tasks/task_e_68457e0a862c83218267f07d85d37b26