### PR TITLE
Add additional ml tensor ops

### DIFF
--- a/crates/ml/src/tensor.rs
+++ b/crates/ml/src/tensor.rs
@@ -388,4 +388,182 @@ impl Tensor {
         tensors.insert(out.id, out.clone());
         out
     }
+
+    pub fn div(
+        &self,
+        other: &Self,
+        recorder: &mut impl Recorder,
+        tensors: &mut HashMap<usize, Tensor>,
+    ) -> Self {
+        assert_eq!(self.shape, other.shape);
+        let data = self
+            .data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(a, b)| a / b)
+            .collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Div,
+                a: self.id,
+                b: other.id,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn neg(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| -*x).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Neg,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn relu(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| x.max(0.0)).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Relu,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn sigmoid(
+        &self,
+        recorder: &mut impl Recorder,
+        tensors: &mut HashMap<usize, Tensor>,
+    ) -> Self {
+        let data = self.data.iter().map(|x| 1.0 / (1.0 + (-*x).exp())).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Sigmoid,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn log(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| x.ln()).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Log,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn sqrt(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| x.sqrt()).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Sqrt,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn rsqrt(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| 1.0 / x.sqrt()).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Rsqrt,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn max(
+        &self,
+        other: &Self,
+        recorder: &mut impl Recorder,
+        tensors: &mut HashMap<usize, Tensor>,
+    ) -> Self {
+        assert_eq!(self.shape, other.shape);
+        let data = self
+            .data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(a, b)| a.max(*b))
+            .collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Max,
+                a: self.id,
+                b: other.id,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    pub fn reduce_max(
+        &self,
+        recorder: &mut impl Recorder,
+        tensors: &mut HashMap<usize, Tensor>,
+    ) -> Self {
+        let max_val = self
+            .data
+            .iter()
+            .cloned()
+            .fold(f32::NEG_INFINITY, f32::max);
+        let out = Tensor::from_vec(vec![1], vec![max_val]);
+        recorder.record(
+            Node {
+                op: EOp::ReduceMax,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
 }


### PR DESCRIPTION
## Summary
- extend EOp and Graph to handle more kernels
- implement additional tensor operations for div, relu, etc.
- backpropagate through the new ops in Tape

## Testing
- `cargo test -p ml`
- `cargo test` *(fails: validate_kernel_shaders_compile)*

------
https://chatgpt.com/codex/tasks/task_e_684597c65d8083219b062ab2a96f4a61