### PR TITLE
Add PhysicsSim builder utilities and fix shader compile

### DIFF
--- a/crates/physics/tests/api.rs
+++ b/crates/physics/tests/api.rs
@@ -1,0 +1,21 @@
+use physics::{PhysicsSim, Vec3};
+
+#[test]
+fn add_sphere_updates_force_len() {
+    let mut sim = PhysicsSim::new();
+    assert_eq!(sim.spheres.len(), 0);
+    let idx = sim.add_sphere(Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+    assert_eq!(idx, 0);
+    assert_eq!(sim.spheres.len(), 1);
+    assert_eq!(sim.params.forces.len(), 1);
+}
+
+#[test]
+fn set_force_affects_simulation() {
+    let mut sim = PhysicsSim::new();
+    sim.add_sphere(Vec3::new(0.0, 0.0, 0.0), Vec3::new(0.0, 0.0, 0.0));
+    sim.params.gravity = Vec3::new(0.0, 0.0, 0.0);
+    sim.set_force(0, [1.0, 0.0]);
+    let _ = sim.run(0.1, 1).unwrap();
+    assert!(sim.spheres[0].pos.x > 0.0);
+}

--- a/shaders/expand_instances.wgsl
+++ b/shaders/expand_instances.wgsl
@@ -1,14 +1,14 @@
-@group(0) @binding(0) var<storage, read> template: array<f32>;
+@group(0) @binding(0) var<storage, read> tmpl: array<f32>;
 @group(0) @binding(3) var<storage, read_write> out: array<f32>;
 @group(0) @binding(4) var<uniform> cfg: u32; // count
 
 @compute @workgroup_size(1)
 fn main() {
     let count = cfg;
-    let len = arrayLength(&template);
+    let len = arrayLength(&tmpl);
     for (var c: u32 = 0u; c < count; c = c + 1u) {
         for (var i: u32 = 0u; i < len; i = i + 1u) {
-            out[c * len + i] = template[i];
+            out[c * len + i] = tmpl[i];
         }
     }
 }

--- a/shaders/segmented_reduce_sum.wgsl
+++ b/shaders/segmented_reduce_sum.wgsl
@@ -8,7 +8,12 @@ fn main() {
     let seg_count = arrayLength(&segments);
     for (var s: u32 = 0u; s < seg_count; s = s + 1u) {
         let start = segments[s];
-        let end = if (s + 1u < seg_count) { segments[s + 1u] } else { arrayLength(&data_in) };
+        var end: u32;
+        if (s + 1u < seg_count) {
+            end = segments[s + 1u];
+        } else {
+            end = arrayLength(&data_in);
+        }
         var sum: f32 = 0.0;
         for (var i: u32 = start; i < end; i = i + 1u) {
             sum = sum + data_in[i];


### PR DESCRIPTION
## Summary
- extend the physics simulation API with helper methods
- fix WGSL shader syntax errors so compile tests pass
- add unit tests covering the new API

## Testing
- `cargo test -p physics --quiet`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684597a562f483218af3f116bd45b5c2