### PR TITLE
Expand ML tensor ops

### DIFF
--- a/crates/ml/src/tensor.rs
+++ b/crates/ml/src/tensor.rs
@@ -109,6 +109,34 @@ impl Tensor {
         out
     }
 
+    /// Performs element-wise division between two tensors.
+    pub fn div(
+        &self,
+        other: &Self,
+        recorder: &mut impl Recorder,
+        tensors: &mut HashMap<usize, Tensor>,
+    ) -> Self {
+        assert_eq!(self.shape, other.shape);
+        let data = self
+            .data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(a, b)| a / b)
+            .collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Div,
+                a: self.id,
+                b: other.id,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
     /// Reduces a tensor to a single value by summing all its elements.
     pub fn reduce_sum(
         &self,
@@ -120,6 +148,23 @@ impl Tensor {
         recorder.record(
             Node {
                 op: EOp::ReduceSum,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Negates each element of the tensor.
+    pub fn neg(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| -*x).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Neg,
                 a: self.id,
                 b: 0,
                 out: out.id,
@@ -379,6 +424,117 @@ impl Tensor {
         recorder.record(
             Node {
                 op: EOp::Exp,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Applies the natural logarithm to each element of the tensor.
+    pub fn log(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| x.ln()).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Log,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Applies the square root to each element of the tensor.
+    pub fn sqrt(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| x.sqrt()).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Sqrt,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Applies the rectified linear unit function to each element.
+    pub fn relu(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| x.max(0.0)).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Relu,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Applies the sigmoid function to each element.
+    pub fn sigmoid(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let data = self.data.iter().map(|x| 1.0 / (1.0 + (-x).exp())).collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Sigmoid,
+                a: self.id,
+                b: 0,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Computes the element-wise maximum of two tensors.
+    pub fn max(&self, other: &Self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        assert_eq!(self.shape, other.shape);
+        let data = self
+            .data
+            .iter()
+            .zip(other.data.iter())
+            .map(|(a, b)| a.max(*b))
+            .collect();
+        let out = Tensor::from_vec(self.shape.clone(), data);
+        recorder.record(
+            Node {
+                op: EOp::Max,
+                a: self.id,
+                b: other.id,
+                out: out.id,
+            },
+            tensors,
+        );
+        tensors.insert(out.id, out.clone());
+        out
+    }
+
+    /// Reduces a tensor to its maximum element.
+    pub fn reduce_max(&self, recorder: &mut impl Recorder, tensors: &mut HashMap<usize, Tensor>) -> Self {
+        let max_val = self
+            .data
+            .iter()
+            .fold(f32::NEG_INFINITY, |a, &b| a.max(b));
+        let out = Tensor::from_vec(vec![1], vec![max_val]);
+        recorder.record(
+            Node {
+                op: EOp::ReduceMax,
                 a: self.id,
                 b: 0,
                 out: out.id,

--- a/crates/ml/tests/07_extra_ops.rs
+++ b/crates/ml/tests/07_extra_ops.rs
@@ -1,0 +1,35 @@
+use ml::graph::Graph;
+use ml::recorder::Recorder;
+use ml::*;
+use std::collections::HashMap;
+
+#[test]
+fn extra_tensor_ops() {
+    let mut g = Graph::new();
+    let mut tensors = HashMap::new();
+
+    let a = Tensor::from_vec(vec![2], vec![1.0, 4.0]);
+    let b = Tensor::from_vec(vec![2], vec![2.0, 5.0]);
+    tensors.insert(a.id, a.clone());
+    tensors.insert(b.id, b.clone());
+
+    let div = a.div(&b, &mut g, &mut tensors);
+    let neg = a.neg(&mut g, &mut tensors);
+    let log = a.log(&mut g, &mut tensors);
+    let sqrt = b.sqrt(&mut g, &mut tensors);
+    let relu = neg.relu(&mut g, &mut tensors);
+    let sig = a.sigmoid(&mut g, &mut tensors);
+    let max = a.max(&b, &mut g, &mut tensors);
+    let max_r = a.reduce_max(&mut g, &mut tensors);
+
+    assert_eq!(div.data(), &[0.5, 0.8]);
+    assert_eq!(neg.data(), &[-1.0, -4.0]);
+    for (o,e) in log.data().iter().zip([1.0f32.ln(), 4.0f32.ln()].iter()) {assert!((o-e).abs()<1e-6);}
+    for (o,e) in sqrt.data().iter().zip([2.0f32.sqrt(), 5.0f32.sqrt()].iter()) {assert!((o-e).abs()<1e-6);}
+    assert_eq!(relu.data(), &[0.0, 0.0]);
+    for (o,e) in sig.data().iter().zip([1.0/(1.0+(-1.0f32).exp()), 1.0/(1.0+(-4.0f32).exp())].iter()) {assert!((o-e).abs()<1e-6);}
+    assert_eq!(max.data(), &[2.0, 5.0]);
+    assert_eq!(max_r.data(), &[4.0]);
+    assert_eq!(g.nodes().len(), 8);
+}
+


### PR DESCRIPTION
## Summary
- extend `EOp` variants with many common math ops
- wire up new operations inside `Graph::run`
- implement gradients for the new ops in `Tape`
- add elementwise math helpers to `Tensor`
- test extra tensor operations

## Testing
- `cargo test -p ml --tests --quiet`
- `cargo test --quiet` *(fails: validate_kernel_shaders_compile)*

------
https://chatgpt.com/codex/tasks/task_e_684597c6cca88321983013864cba620f