### PR TITLE
Introduce Env trait and update StickBalanceEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ construct creature bodies.
 
 The repository now contains a minimal physics setup for a classic control task:
 balancing a stick on a moving cart. The `StickBalanceEnv` in the `ml` crate
-exposes an `Env` implementation backed by the physics engine. A new test file
+exposes an `Env` implementation (`ml::env::Env`) backed by the physics engine. A new test file
 exercises this environment by stepping it with zero actions and verifying that
 the episode terminates once the pole falls over. No learning happens yet—this is
 purely a skeleton for future reinforcement learning experiments.

--- a/crates/ml/src/env.rs
+++ b/crates/ml/src/env.rs
@@ -1,0 +1,25 @@
+/// Reinforcement learning environment trait.
+///
+/// Inspired by classic frameworks like OpenAI Gym, this trait defines the core
+/// interface an environment must provide. Each call to [`step`] advances the
+/// simulation by one action and returns the new observation vector, a reward
+/// signal, and whether the episode has terminated.
+///
+/// [`step`]: Env::step
+pub trait Env {
+    /// Advance the environment by one action.
+    ///
+    /// Returns `(obs, reward, done)` where `obs` is the new observation vector,
+    /// `reward` is the scalar reward, and `done` indicates episode termination.
+    fn step(&mut self, action: f32) -> (Vec<f32>, f32, bool);
+
+    /// Reset the environment to its starting state and return the initial
+    /// observation vector.
+    fn reset(&mut self) -> Vec<f32>;
+
+    /// Size of the observation vector.
+    fn obs_size(&self) -> usize;
+
+    /// Size of the action space.
+    fn action_size(&self) -> usize;
+}

--- a/crates/ml/src/lib.rs
+++ b/crates/ml/src/lib.rs
@@ -2,6 +2,7 @@ pub mod graph;
 pub mod nn;
 pub mod optim;
 pub mod recorder;
+pub mod env;
 pub mod rl;
 pub mod stick_balance;
 pub mod tape;
@@ -9,3 +10,4 @@ pub mod tensor;
 
 pub use tensor::Tensor;
 pub use stick_balance::StickBalanceEnv;
+pub use env::Env;

--- a/crates/ml/src/rl.rs
+++ b/crates/ml/src/rl.rs
@@ -1,14 +1,4 @@
-/// A trait for reinforcement learning environments.
-pub trait Env {
-    /// Steps the environment forward by one time-step.
-    fn step(&mut self, action: f32) -> (Vec<f32>, f32, bool);
-    /// Resets the environment to an initial state.
-    fn reset(&mut self) -> Vec<f32>;
-    /// Returns the size of the observation space.
-    fn obs_size(&self) -> usize;
-    /// Returns the size of the action space.
-    fn action_size(&self) -> usize;
-}
+use crate::env::Env;
 
 /// A simple environment where the agent must learn to roll a sphere to the right.
 pub struct RollingSphereEnv {

--- a/crates/ml/src/stick_balance.rs
+++ b/crates/ml/src/stick_balance.rs
@@ -1,5 +1,5 @@
 use physics::{PhysicsSim, Sphere, Vec3, Joint};
-use crate::rl::Env;
+use crate::env::Env;
 
 /// Environment for balancing a stick by applying a horizontal force to the base sphere.
 ///

--- a/crates/ml/tests/07_stick_balance_env.rs
+++ b/crates/ml/tests/07_stick_balance_env.rs
@@ -1,5 +1,5 @@
 use ml::StickBalanceEnv;
-use ml::rl::Env;
+use ml::env::Env;
 
 /// Basic sanity test for the stick balancing environment.
 ///


### PR DESCRIPTION
## Summary
- add new `Env` trait in `ml::env`
- export new module from `ml` crate
- update RL and StickBalanceEnv to use the trait
- tweak README about the trait location
- adjust tests to the new path

## Testing
- `cargo test -p ml --test 07_stick_balance_env --quiet`
- `cargo test -p ml --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846a29ec4048321a376ecb221166e55