### PR TITLE
Add cart pole falling test

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ the episode terminates once the pole falls over. No learning happens yet—this 
 purely a skeleton for future reinforcement learning experiments.
 
 The command `cargo test -p ml --test 07_stick_balance_env` will run this test specifically.
+Another test, `cargo test -p ml --test 08_cart_pole`, starts the pole at a slight angle
+and confirms it falls over when no control is applied.
 
 ## Status
 

--- a/crates/ml/src/stick_balance.rs
+++ b/crates/ml/src/stick_balance.rs
@@ -29,6 +29,16 @@ impl StickBalanceEnv {
         Self { sim, base_idx: 0, tip_idx: 1 }
     }
 
+    /// Resets the environment with the tip offset by the given angle in radians.
+    /// A small angle will cause the pole to fall over when no control is applied.
+    pub fn reset_with_angle(&mut self, angle: f32) -> Vec<f32> {
+        self.sim.spheres[self.base_idx].pos = Vec3::new(0.0, 0.0, 0.0);
+        self.sim.spheres[self.base_idx].vel = Vec3::new(0.0, 0.0, 0.0);
+        self.sim.spheres[self.tip_idx].pos = Vec3::new(-angle.sin(), angle.cos(), 0.0);
+        self.sim.spheres[self.tip_idx].vel = Vec3::new(0.0, 0.0, 0.0);
+        vec![0.0, angle]
+    }
+
     /// Returns the angle of the stick relative to the vertical axis.
     fn stick_angle(&self) -> f32 {
         let base = &self.sim.spheres[self.base_idx];

--- a/crates/ml/tests/08_cart_pole.rs
+++ b/crates/ml/tests/08_cart_pole.rs
@@ -1,0 +1,20 @@
+use ml::StickBalanceEnv;
+use ml::rl::Env;
+
+/// Runs the cart-pole (stick balance) environment with zero control.
+/// Starting from a small angle offset, the pole should fall over
+/// without intervention and the episode should terminate.
+#[test]
+fn cart_pole_falls_without_control() {
+    let mut env = StickBalanceEnv::new();
+    let _ = env.reset_with_angle(0.05);
+    let mut done = false;
+    for _ in 0..200 {
+        let (_obs, _r, d) = env.step(0.0);
+        if d {
+            done = true;
+            break;
+        }
+    }
+    assert!(done, "episode should end once the pole falls over");
+}


### PR DESCRIPTION
## Summary
- add a `reset_with_angle` helper to StickBalanceEnv
- update cart pole integration test to expect the pole to fall
- document how to run the new test

## Testing
- `cargo test -p ml --test 08_cart_pole -- --nocapture`
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_6846a26df3608321ae9d1f4fc606d935