### PR TITLE
Train PPO on cart-pole

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ purely a skeleton for future reinforcement learning experiments.
 The command `cargo test -p ml --test 07_stick_balance_env` will run this test specifically.
 Another test, `cargo test -p ml --test 08_cart_pole`, starts the pole at a slight angle
 and confirms it falls over when no control is applied.
+`cargo test -p ml --test 09_cart_pole_control` verifies that applying a horizontal
+force moves the cart. Finally the ignored test
+`cargo test -p ml --test 10_cart_pole_train -- --ignored` runs a small PPO
+training loop that learns a policy. The test also verifies the trained policy
+can keep the pole upright for an entire episode.
 
 ## Status
 

--- a/crates/ml/tests/08_cart_pole.rs
+++ b/crates/ml/tests/08_cart_pole.rs
@@ -1,5 +1,5 @@
 use ml::StickBalanceEnv;
-use ml::rl::Env;
+use ml::Env;
 
 /// Runs the cart-pole (stick balance) environment with zero control.
 /// Starting from a small angle offset, the pole should fall over

--- a/crates/ml/tests/09_cart_pole_control.rs
+++ b/crates/ml/tests/09_cart_pole_control.rs
@@ -1,0 +1,15 @@
+use ml::StickBalanceEnv;
+use ml::Env;
+
+#[test]
+fn cart_pole_base_moves() {
+    let mut env = StickBalanceEnv::new();
+    let mut obs = env.reset();
+    assert_eq!(obs.len(), 2);
+    for _ in 0..10 {
+        let (o, _r, _d) = env.step(5.0);
+        obs = o;
+    }
+    // the base position is the first element of the observation
+    assert!(obs[0] > 0.0, "cart should move right with positive force");
+}

--- a/crates/ml/tests/10_cart_pole_train.rs
+++ b/crates/ml/tests/10_cart_pole_train.rs
@@ -1,0 +1,32 @@
+use ml::rl::StickBalancePpoTrainer;
+use ml::StickBalanceEnv;
+use ml::Env;
+
+#[test]
+#[ignore]
+fn ppo_learns_to_balance_cart_pole() {
+    let mut trainer = StickBalancePpoTrainer::new(0);
+    let mut best = 0.0f32;
+    for _ in 0..500 { // 500 training iterations
+        let reward = trainer.step();
+        if reward > best {
+            best = reward;
+        }
+        if best > 50.0 { // close to perfect (64)
+            break;
+        }
+    }
+    assert!(best > 50.0, "best {best}");
+
+    // Verify that the trained policy keeps the pole balanced for many steps.
+    let mut env = StickBalanceEnv::new();
+    let mut obs = env.reset();
+    for i in 0..100 {
+        let action = trainer.act(&obs);
+        let (o, _r, done) = env.step(action);
+        obs = o;
+        if done {
+            panic!("fell over after {} steps", i);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a generic PPO trainer and alias `StickBalancePpoTrainer`
- add cart-pole control and training tests
- test that the trained policy balances the cart-pole for a full episode
- document updated training test

## Testing
- `cargo test --workspace --lib --tests -- --skip ppo_learns_to_balance_cart_pole --skip cart_pole_train`
- `cargo test --test 10_cart_pole_train ppo_learns_to_balance_cart_pole -- --ignored --exact --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_6846a9450a9c83219af72106381706b0