### PR TITLE
Add phenotype parser with JSON examples

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/physics",
     "crates/ml",
     "crates/render",
+    "crates/phenotype",
 ]
 resolver = "2"
 

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ purely a skeleton for future reinforcement learning experiments.
 The command `cargo test -p ml --test 07_stick_balance_env` will run this test specifically.
 Another test, `cargo test -p ml --test 08_cart_pole`, starts the pole at a slight angle
 and confirms it falls over when no control is applied.
+`cargo test -p ml --test 09_cart_pole_control` verifies that applying a horizontal
+force moves the cart. Finally the ignored test
+`cargo test -p ml --test 10_cart_pole_train -- --ignored` runs a small PPO
+training loop that learns a policy. The test also verifies the trained policy
+can keep the pole upright for an entire episode.
 
 ## Status
 

--- a/crates/ml/tests/07_stick_balance_env.rs
+++ b/crates/ml/tests/07_stick_balance_env.rs
@@ -1,5 +1,5 @@
 use ml::StickBalanceEnv;
-use ml::env::Env;
+use ml::Env;
 
 /// Basic sanity test for the stick balancing environment.
 ///

--- a/crates/ml/tests/08_cart_pole.rs
+++ b/crates/ml/tests/08_cart_pole.rs
@@ -1,5 +1,5 @@
 use ml::StickBalanceEnv;
-use ml::rl::Env;
+use ml::env::Env;
 
 /// Runs the cart-pole (stick balance) environment with zero control.
 /// Starting from a small angle offset, the pole should fall over

--- a/crates/ml/tests/08_cart_pole.rs
+++ b/crates/ml/tests/08_cart_pole.rs
@@ -1,5 +1,5 @@
 use ml::StickBalanceEnv;
-use ml::env::Env;
+use ml::Env;
 
 /// Runs the cart-pole (stick balance) environment with zero control.
 /// Starting from a small angle offset, the pole should fall over

--- a/crates/ml/tests/09_cart_pole_control.rs
+++ b/crates/ml/tests/09_cart_pole_control.rs
@@ -1,0 +1,15 @@
+use ml::StickBalanceEnv;
+use ml::Env;
+
+#[test]
+fn cart_pole_base_moves() {
+    let mut env = StickBalanceEnv::new();
+    let mut obs = env.reset();
+    assert_eq!(obs.len(), 2);
+    for _ in 0..10 {
+        let (o, _r, _d) = env.step(5.0);
+        obs = o;
+    }
+    // the base position is the first element of the observation
+    assert!(obs[0] > 0.0, "cart should move right with positive force");
+}

--- a/crates/ml/tests/10_cart_pole_train.rs
+++ b/crates/ml/tests/10_cart_pole_train.rs
@@ -1,0 +1,32 @@
+use ml::rl::StickBalancePpoTrainer;
+use ml::StickBalanceEnv;
+use ml::Env;
+
+#[test]
+#[ignore]
+fn ppo_learns_to_balance_cart_pole() {
+    let mut trainer = StickBalancePpoTrainer::new(0);
+    let mut best = 0.0f32;
+    for _ in 0..500 { // 500 training iterations
+        let reward = trainer.step();
+        if reward > best {
+            best = reward;
+        }
+        if best > 50.0 { // close to perfect (64)
+            break;
+        }
+    }
+    assert!(best > 50.0, "best {best}");
+
+    // Verify that the trained policy keeps the pole balanced for many steps.
+    let mut env = StickBalanceEnv::new();
+    let mut obs = env.reset();
+    for i in 0..100 {
+        let action = trainer.act(&obs);
+        let (o, _r, done) = env.step(action);
+        obs = o;
+        if done {
+            panic!("fell over after {} steps", i);
+        }
+    }
+}

--- a/crates/phenotype/Cargo.toml
+++ b/crates/phenotype/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "phenotype"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+anyhow = "1.0"
+physics = { path = "../physics" }

--- a/crates/phenotype/src/lib.rs
+++ b/crates/phenotype/src/lib.rs
@@ -1,0 +1,113 @@
+#![deny(clippy::all, clippy::pedantic)]
+
+use anyhow::Result;
+use physics::{PhysicsSim, Vec3};
+use serde::Deserialize;
+use std::collections::HashMap;
+
+#[derive(Deserialize)]
+pub struct Phenotype {
+    pub bodies: Vec<Body>,
+    #[serde(default)]
+    pub joints: Vec<JointDef>,
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "shape")]
+pub enum Body {
+    #[serde(rename = "sphere")]
+    Sphere {
+        id: String,
+        radius: f32,
+        pos: [f32; 3],
+        #[serde(default = "zero_vec")] 
+        vel: [f32; 3],
+    },
+    #[serde(rename = "box")]
+    Box {
+        id: String,
+        half_extents: [f32; 3],
+        pos: [f32; 3],
+        #[serde(default = "zero_vec")] 
+        vel: [f32; 3],
+    },
+    #[serde(rename = "cylinder")]
+    Cylinder {
+        id: String,
+        radius: f32,
+        height: f32,
+        pos: [f32; 3],
+        #[serde(default = "zero_vec")] 
+        vel: [f32; 3],
+    },
+    #[serde(rename = "plane")]
+    Plane {
+        id: String,
+        normal: [f32; 3],
+        d: f32,
+    },
+}
+
+#[derive(Deserialize)]
+pub struct JointDef {
+    pub body_a: String,
+    pub body_b: String,
+    pub rest_length: f32,
+}
+
+fn zero_vec() -> [f32; 3] {
+    [0.0, 0.0, 0.0]
+}
+
+impl Phenotype {
+    #[must_use]
+    pub fn from_str(json: &str) -> Result<Self> {
+        Ok(serde_json::from_str(json)?)
+    }
+
+    pub fn into_sim(self) -> Result<PhysicsSim> {
+        let mut sim = PhysicsSim::new();
+        let mut map: HashMap<String, usize> = HashMap::new();
+        for body in self.bodies {
+            match body {
+                Body::Sphere { id, radius: _, pos, vel } => {
+                    let idx = sim.add_sphere(Vec3::new(pos[0], pos[1], pos[2]), Vec3::new(vel[0], vel[1], vel[2]));
+                    map.insert(id, idx);
+                }
+                Body::Box { id, half_extents, pos, vel } => {
+                    let idx = sim.add_box(
+                        Vec3::new(pos[0], pos[1], pos[2]),
+                        Vec3::new(half_extents[0], half_extents[1], half_extents[2]),
+                        Vec3::new(vel[0], vel[1], vel[2]),
+                    );
+                    map.insert(id, idx);
+                }
+                Body::Cylinder { id, radius, height, pos, vel } => {
+                    let idx = sim.add_cylinder(
+                        Vec3::new(pos[0], pos[1], pos[2]),
+                        radius,
+                        height,
+                        Vec3::new(vel[0], vel[1], vel[2]),
+                    );
+                    map.insert(id, idx);
+                }
+                Body::Plane { id, normal, d } => {
+                    let idx = sim.add_plane(Vec3::new(normal[0], normal[1], normal[2]), d);
+                    map.insert(id, idx);
+                }
+            }
+        }
+
+        for joint in self.joints {
+            let a = map
+                .get(&joint.body_a)
+                .ok_or_else(|| anyhow::anyhow!("unknown body {}", joint.body_a))?;
+            let b = map
+                .get(&joint.body_b)
+                .ok_or_else(|| anyhow::anyhow!("unknown body {}", joint.body_b))?;
+            sim.add_joint(*a as u32, *b as u32, joint.rest_length);
+        }
+
+        Ok(sim)
+    }
+}

--- a/crates/phenotype/tests/data/box_cylinder.json
+++ b/crates/phenotype/tests/data/box_cylinder.json
@@ -1,0 +1,9 @@
+{
+  "bodies": [
+    {"id": "box", "shape": "box", "half_extents": [0.5,0.5,0.5], "pos": [0,3,0]},
+    {"id": "cyl", "shape": "cylinder", "radius": 0.25, "height": 1.0, "pos": [0,4,0]}
+  ],
+  "joints": [
+    {"body_a": "box", "body_b": "cyl", "rest_length": 1.0}
+  ]
+}

--- a/crates/phenotype/tests/data/chain.json
+++ b/crates/phenotype/tests/data/chain.json
@@ -1,0 +1,11 @@
+{
+  "bodies": [
+    {"id": "a", "shape": "sphere", "radius": 1.0, "pos": [0, 1, 0]},
+    {"id": "b", "shape": "sphere", "radius": 1.0, "pos": [1, 1, 0]},
+    {"id": "c", "shape": "sphere", "radius": 1.0, "pos": [2, 1, 0]}
+  ],
+  "joints": [
+    {"body_a": "a", "body_b": "b", "rest_length": 1.0},
+    {"body_a": "b", "body_b": "c", "rest_length": 1.0}
+  ]
+}

--- a/crates/phenotype/tests/data/sphere_plane.json
+++ b/crates/phenotype/tests/data/sphere_plane.json
@@ -1,0 +1,7 @@
+{
+  "bodies": [
+    {"id": "ground", "shape": "plane", "normal": [0,1,0], "d": 0.0},
+    {"id": "ball", "shape": "sphere", "radius": 1.0, "pos": [0,2,0]}
+  ],
+  "joints": []
+}

--- a/crates/phenotype/tests/parser.rs
+++ b/crates/phenotype/tests/parser.rs
@@ -1,0 +1,35 @@
+use phenotype::Phenotype;
+use std::fs;
+
+#[test]
+fn parse_chain_example() {
+    let json = fs::read_to_string("tests/data/chain.json").unwrap();
+    let p = Phenotype::from_str(&json).unwrap();
+    assert_eq!(p.bodies.len(), 3);
+    assert_eq!(p.joints.len(), 2);
+}
+
+#[test]
+fn sim_from_chain_runs() {
+    let json = fs::read_to_string("tests/data/chain.json").unwrap();
+    let p = Phenotype::from_str(&json).unwrap();
+    let mut sim = p.into_sim().unwrap();
+    sim.run_cpu(0.01, 5);
+    assert_eq!(sim.spheres.len(), 3);
+}
+
+#[test]
+fn parse_box_cylinder() {
+    let json = fs::read_to_string("tests/data/box_cylinder.json").unwrap();
+    let p = Phenotype::from_str(&json).unwrap();
+    assert_eq!(p.bodies.len(), 2);
+    assert_eq!(p.joints.len(), 1);
+}
+
+#[test]
+fn parse_plane_sphere() {
+    let json = fs::read_to_string("tests/data/sphere_plane.json").unwrap();
+    let p = Phenotype::from_str(&json).unwrap();
+    assert_eq!(p.bodies.len(), 2);
+    assert!(p.joints.is_empty());
+}


### PR DESCRIPTION
## Summary
- add new `phenotype` crate for loading body definitions
- wire new crate into workspace
- include sample phenotype JSON files
- test phenotype parsing and simulation
- fix import in ml cart pole test

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846af1dec6083219835d17c4a7f7e35