### PR TITLE
Improve runtime docs

### DIFF
--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1,3 +1,10 @@
+//! Simulation loop tying physics, rendering and shader watching together.
+//!
+//! The [`run`] function is called from the binary's [`main`](crate::main) and
+//! drives a short physics example. When built with the `render` feature a
+//! real-time window visualises the scene while WGSL shader files are watched
+//! for changes so they can be reloaded on the fly.
+
 use anyhow::Result;
 use physics::PhysicsSim;
 
@@ -6,6 +13,20 @@ use render::Renderer;
 
 use crate::watcher;
 
+/// Run the main physics simulation loop.
+///
+/// When `enable_render` is `true` and the crate is compiled with the `render`
+/// feature, a `Renderer` window displays the positions of the
+/// simulated spheres. WGSL files in the `shaders/` directory are watched for
+/// changes so compute pipelines can be reloaded on the fly through
+/// [`crate::watcher`].
+///
+/// The loop steps a [`physics::PhysicsSim`] containing a single sphere and logs
+/// progress every few frames.
+///
+/// # Errors
+///
+/// Returns any error produced by the physics engine, renderer or file watcher.
 pub fn run(_enable_render: bool) -> Result<()> {
     tracing_subscriber::fmt::init();
 

--- a/crates/runtime/src/main.rs
+++ b/crates/runtime/src/main.rs
@@ -1,15 +1,20 @@
 #![deny(clippy::all, clippy::pedantic)]
 #![allow(clippy::unnecessary_wraps)]
-//! Entry point for running simulations and tests.
+//! Entry point for the runtime binary.
 //!
-//! This binary wires together the compute, physics and optional rendering
-//! crates. Pass `--draw` to enable a real time window showing the simulation.
+//! This crate ties together the compute, physics and optional rendering
+//! layers. A lightweight file watcher allows WGSL shaders to be hot reloaded
+//! during development. Run with `--draw` to open a window visualising the
+//! simulation.
 
 mod app;
 mod watcher;
 
 use anyhow::Result;
 
+/// Parses command line arguments and launches [`app::run`].
+///
+/// Returns any error encountered during simulation setup or execution.
 fn main() -> Result<()> {
     let enable_render = std::env::args().any(|a| a == "--draw");
     app::run(enable_render)

--- a/crates/runtime/src/watcher.rs
+++ b/crates/runtime/src/watcher.rs
@@ -1,9 +1,19 @@
+//! Utilities for hot-reloading WGSL shaders at runtime.
+//!
+//! The [`start`] function spawns a [`notify`] watcher that monitors the
+//! `shaders/` directory. When a `.wgsl` file changes, the path is fed into the
+//! [`reload_shader`] callback which will eventually rebuild the GPU pipeline.
+
 use anyhow::Result;
 use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher as NotifyWatcher};
 use std::path::Path;
 use tracing::info;
 
-// Placeholder for actual reload logic
+/// Placeholder callback invoked whenever a shader file changes.
+///
+/// Currently this simply logs the change. In future iterations it will
+/// recreate the `wgpu` pipeline so that modified compute and render shaders
+/// take effect without restarting the application.
 fn reload_shader(path: &Path) {
     info!(
         "Shader changed: {:?}. Triggering reload (placeholder).",
@@ -12,6 +22,16 @@ fn reload_shader(path: &Path) {
     // In Phase 1, this will re-create the wgpu pipeline.
 }
 
+/// Begin watching the `shaders/` directory for WGSL file changes.
+///
+/// The returned [`RecommendedWatcher`] must be kept alive by the caller to
+/// continue receiving events. For every modification or creation of a `.wgsl`
+/// file [`reload_shader`] is invoked.
+///
+/// # Errors
+///
+/// Propagates any errors from the underlying [`notify`] crate when setting up
+/// the watcher or adding the directory to be watched.
 pub fn start() -> Result<RecommendedWatcher> {
     info!("Initializing shader watcher...");
 


### PR DESCRIPTION
## Summary
- document shader watcher utilities
- add details on the simulation loop
- expand crate level docs for the runtime binary

## Testing
- `cargo doc -p runtime --no-deps --quiet`
- `cargo test -p runtime --quiet`

------
https://chatgpt.com/codex/tasks/task_e_6846b5e24f608321a733feeb4651b187