### PR TITLE
Add documentation for compute crate

### DIFF
--- a/crates/compute/src/backend/mock_cpu.rs
+++ b/crates/compute/src/backend/mock_cpu.rs
@@ -1,6 +1,7 @@
 
 #[cfg(feature = "mock")]
 #[derive(Default)]
+/// Simplified CPU backend used for mocking during tests.
 pub struct MockCpu;
 
 #[cfg(feature = "mock")]

--- a/crates/compute/src/cpu_backend.rs
+++ b/crates/compute/src/cpu_backend.rs
@@ -8,7 +8,10 @@
 use crate::{kernels, BufferView, ComputeBackend, ComputeError, Kernel};
 
 #[derive(Default, Debug, Clone)]
-/// Simple compute backend that runs kernels on the host CPU.
+/// Reference implementation of [`ComputeBackend`] that executes kernels on the CPU.
+///
+/// While not optimized for performance, this backend is useful for testing and
+/// environments without GPU support.
 pub struct CpuBackend;
 
 impl CpuBackend {

--- a/crates/compute/src/kernels/add_broadcast_op.rs
+++ b/crates/compute/src/kernels/add_broadcast_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Adds a vector to each row of a matrix.
+///
+/// Bindings `[a, b, output_placeholder]` expect `a` shaped `[batch, dim]` and
+/// `b` shaped `[dim]`. The broadcasted sum is returned in a single buffer.
 pub fn handle_add_broadcast(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/add_op.rs
+++ b/crates/compute/src/kernels/add_op.rs
@@ -1,7 +1,11 @@
 use crate::{BufferView, ComputeError};
-// std::sync::Arc is not directly used by handle_add, BufferView handles its own Arc.
 
-// Add operation handler
+/// Element-wise addition of two buffers.
+///
+/// The function expects three bindings: the first two are input buffers `a` and
+/// `b` containing `f32` values, while the third is a placeholder for the output
+/// buffer. All inputs must have the same shape and element size. The returned
+/// vector contains a single buffer with the computed sums.
 pub fn handle_add(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch("Add kernel expects 3 buffers"));

--- a/crates/compute/src/kernels/clamp_op.rs
+++ b/crates/compute/src/kernels/clamp_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Restricts each element of `value` to the inclusive range `[min, max]`.
+///
+/// Bindings are `[value, min, max, output_placeholder, config]` with matching
+/// shapes. All buffers use `f32` elements. A single buffer with the clamped
+/// values is returned.
 pub fn handle_clamp(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 5 {
         // value, min_val, max_val, out_placeholder, config per layout.rs

--- a/crates/compute/src/kernels/detect_contacts_box_op.rs
+++ b/crates/compute/src/kernels/detect_contacts_box_op.rs
@@ -2,6 +2,7 @@ use crate::{BufferView, ComputeError};
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Simple 3D vector used by the contact detection tests.
 pub struct TestVec3 {
     pub x: f32,
     pub y: f32,
@@ -10,12 +11,14 @@ pub struct TestVec3 {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Body with a single position used in tests.
 pub struct TestBody {
     pub pos: TestVec3,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Box primitive defined by a center and half extents.
 pub struct TestBox {
     pub center: TestVec3,
     pub half_extents: TestVec3,
@@ -23,6 +26,7 @@ pub struct TestBox {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Contact record emitted for each intersecting body.
 pub struct TestContact {
     pub body_index: u32,
     pub normal: TestVec3,
@@ -30,7 +34,12 @@ pub struct TestContact {
     pub _pad: [f32; 3],
 }
 
-/// CPU implementation of sphere-box contact detection for unit spheres.
+/// Detects intersections between unit spheres and a single box.
+///
+/// The bindings are expected to contain a slice of [`TestBody`] instances,
+/// a [`TestBox`] describing the box, and an output buffer to receive
+/// [`TestContact`] records. The resulting vector contains one buffer holding the
+/// contacts for all intersecting bodies.
 pub fn handle_detect_contacts_box(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/detect_contacts_sdf_op.rs
+++ b/crates/compute/src/kernels/detect_contacts_sdf_op.rs
@@ -2,6 +2,7 @@ use crate::{BufferView, ComputeError};
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Basic 3D vector used by the SDF contact tests.
 pub struct TestVec3 {
     pub x: f32,
     pub y: f32,
@@ -10,18 +11,21 @@ pub struct TestVec3 {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Body with a position used for plane contacts.
 pub struct TestBody {
     pub pos: TestVec3,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Height field plane representing an infinite ground surface.
 pub struct TestPlane {
     pub height: f32,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Contact produced when a body penetrates the plane.
 pub struct TestContact {
     pub index: u32,
     pub penetration: f32,

--- a/crates/compute/src/kernels/detect_contacts_sphere.rs
+++ b/crates/compute/src/kernels/detect_contacts_sphere.rs
@@ -2,6 +2,7 @@ use crate::{BufferView, ComputeError};
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Minimal 3D vector used by the sphere contact tests.
 pub struct TestVec3 {
     pub x: f32,
     pub y: f32,
@@ -10,12 +11,14 @@ pub struct TestVec3 {
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Position-only body for unit spheres.
 pub struct TestBody {
     pub pos: TestVec3,
 }
 
 #[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq, bytemuck::Pod, bytemuck::Zeroable)]
+/// Contact information emitted when two spheres overlap.
 pub struct TestContact {
     pub body_index: u32,
     pub normal: TestVec3,
@@ -25,8 +28,10 @@ pub struct TestContact {
 
 /// CPU implementation of simple sphere-sphere contact detection.
 ///
-/// Each sphere is assumed to have unit radius. Contacts are emitted in the
-/// format expected by the `SolveContactsPBD` kernel.
+/// Each body in the first binding is treated as a unit sphere. All pairwise
+/// intersections are detected and written as [`TestContact`] structures into the
+/// output buffer provided as the second binding. The format matches what the
+/// position based dynamics solver expects.
 pub fn handle_detect_contacts_sphere(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 2 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/div_op.rs
+++ b/crates/compute/src/kernels/div_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Element-wise division of two buffers.
+///
+/// Bindings must contain `[a, b, output_placeholder, config]` with matching
+/// shapes. Division is performed on `f32` values and the result is returned in a
+/// single output buffer.
 pub fn handle_div(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         // IN1, IN2, OUT, CONFIG per layout.rs

--- a/crates/compute/src/kernels/exp_op.rs
+++ b/crates/compute/src/kernels/exp_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Applies the exponential function to each element of the input buffer.
+///
+/// Bindings must be `[input, output_placeholder, config]` containing `f32`
+/// values. The computed exponentials are returned in a single output buffer.
 pub fn handle_exp(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         // IN, OUT_placeholder, CONFIG per layout.rs

--- a/crates/compute/src/kernels/expand_instances_op.rs
+++ b/crates/compute/src/kernels/expand_instances_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Copies a template buffer multiple times into the output buffer.
+///
+/// The bindings `[template, output_placeholder, config]` are expected. The
+/// config buffer holds a single `u32` count describing how many times the
+/// template should be repeated.
 pub fn handle_expand_instances(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/gather_op.rs
+++ b/crates/compute/src/kernels/gather_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Collects elements from `source` at the provided indices.
+///
+/// Bindings: `[source, indices, output_placeholder, config]`. The indices are
+/// `u32` offsets into the source buffer. The gathered values are returned in the
+/// output buffer.
 pub fn handle_gather(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/integrate_bodies_op.rs
+++ b/crates/compute/src/kernels/integrate_bodies_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Integrates simple rigid bodies forward in time.
+///
+/// Bindings should be `[bodies_inout, params, forces]`. Each body is updated in
+/// place according to the provided forces and physics parameters. The updated
+/// bodies are returned as a single buffer.
 pub fn handle_integrate_bodies(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/log_op.rs
+++ b/crates/compute/src/kernels/log_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Computes the natural logarithm of each input element.
+///
+/// Expects bindings `[input, output_placeholder, config]` using `f32` values.
+/// Returns one buffer containing the logarithms of the input.
 pub fn handle_log(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         // IN, OUT_placeholder, CONFIG per layout.rs

--- a/crates/compute/src/kernels/matmul_op.rs
+++ b/crates/compute/src/kernels/matmul_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Performs a basic matrix multiplication `C = A * B` on `f32` matrices.
+///
+/// The bindings are `[A, B, output_placeholder, config]` where `config` holds
+/// the matrix dimensions `(m, k, n)` as `u32` values.
 pub fn handle_matmul(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/max_op.rs
+++ b/crates/compute/src/kernels/max_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Computes the pairwise maximum of two buffers.
+///
+/// Bindings are `[a, b, output_placeholder, config]` with identical shapes.
+/// Returns a single buffer containing the maxima of each pair of elements.
 pub fn handle_max(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         // IN1, IN2, OUT, CONFIG per layout.rs

--- a/crates/compute/src/kernels/min_op.rs
+++ b/crates/compute/src/kernels/min_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Computes the pairwise minimum of two buffers.
+///
+/// Bindings `[a, b, output_placeholder, config]` must all be `f32` arrays of the
+/// same shape. The minimum of each pair is returned in a single output buffer.
 pub fn handle_min(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         // IN1, IN2, OUT, CONFIG per layout.rs

--- a/crates/compute/src/kernels/mul_op.rs
+++ b/crates/compute/src/kernels/mul_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Element-wise multiplication of two buffers.
+///
+/// Expects bindings `[a, b, output_placeholder, config]`. All buffers use the
+/// `f32` element type and must share the same shape. The returned vector
+/// contains one buffer with the multiplied values.
 pub fn handle_mul(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         // IN1, IN2, OUT, CONFIG per layout.rs

--- a/crates/compute/src/kernels/neg_op.rs
+++ b/crates/compute/src/kernels/neg_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Negates each element of the input buffer.
+///
+/// The bindings are `[input, output_placeholder, config]` where the input
+/// buffer contains `f32` values. The negated results are returned as a single
+/// buffer inside the returned vector.
 pub fn handle_neg(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         // IN1, OUT, CONFIG per layout.rs

--- a/crates/compute/src/kernels/reduce_max_op.rs
+++ b/crates/compute/src/kernels/reduce_max_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Finds the maximum element of the input buffer.
+///
+/// Expects bindings `[input, output_placeholder, config]` with `f32` values. A
+/// single buffer containing the maximum is returned.
 pub fn handle_reduce_max(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/reduce_mean_op.rs
+++ b/crates/compute/src/kernels/reduce_mean_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Calculates the mean of all elements in the input buffer.
+///
+/// Bindings `[input, output_placeholder, config]` must use `f32` values. The
+/// resulting mean is written to a single buffer which is returned.
 pub fn handle_reduce_mean(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/reduce_sum_op.rs
+++ b/crates/compute/src/kernels/reduce_sum_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Reduces a buffer by summing all of its `f32` elements.
+///
+/// Expects `[input, output_placeholder, config]` as bindings. The returned
+/// vector contains a single buffer with the scalar sum value.
 pub fn handle_reduce_sum(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/relu_op.rs
+++ b/crates/compute/src/kernels/relu_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Applies the rectified linear unit function element-wise.
+///
+/// The input, output placeholder and config buffers are supplied in that order
+/// and must contain `f32` data. The output buffer in the returned vector holds
+/// `max(input, 0)` for each element.
 pub fn handle_relu(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch("Relu kernel expects 3 buffers"));

--- a/crates/compute/src/kernels/rng_normal_op.rs
+++ b/crates/compute/src/kernels/rng_normal_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Generates a deterministic normal distribution for testing purposes.
+///
+/// Bindings `[output_placeholder, config]` specify where the generated `f32`
+/// values are written. The sequence is deterministic and does not use any real
+/// random number generator.
 pub fn handle_rng_normal(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 2 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/rsqrt_op.rs
+++ b/crates/compute/src/kernels/rsqrt_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Computes `1 / sqrt(x)` for each element of the input buffer.
+///
+/// Requires bindings `[input, output_placeholder, config]` and operates on
+/// `f32` data. The single returned buffer contains the reciprocal square roots.
 pub fn handle_rsqrt(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/scatter_add_op.rs
+++ b/crates/compute/src/kernels/scatter_add_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Adds values into an accumulator buffer at specified indices.
+///
+/// Bindings are `[values, indices, accumulator, config]`. The function adds
+/// each value in `values` to the position indicated by the corresponding index.
+/// The updated accumulator is returned.
 pub fn handle_scatter_add(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/segmented_reduce_sum_op.rs
+++ b/crates/compute/src/kernels/segmented_reduce_sum_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Computes sums over segments of the input buffer.
+///
+/// Bindings are `[data, segment_indices, output_placeholder, config]`. Each
+/// segment is defined by consecutive indices in the `segment_indices` buffer.
+/// Returns one buffer where each element contains the sum for a segment.
 pub fn handle_segmented_reduce_sum(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/sigmoid_op.rs
+++ b/crates/compute/src/kernels/sigmoid_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Applies the sigmoid activation `1/(1+exp(-x))` element-wise.
+///
+/// The function expects bindings `[input, output_placeholder, config]` with
+/// `f32` data. A single buffer containing the results is returned.
 pub fn handle_sigmoid(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/solve_contacts_pbd_op.rs
+++ b/crates/compute/src/kernels/solve_contacts_pbd_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Resolves penetration contacts using a simple position based dynamics step.
+///
+/// The expected bindings are `[bodies_inout, contacts, params]`. Updated body
+/// data is returned in a single buffer.
 pub fn handle_solve_contacts_pbd(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/solve_joints_pbd_op.rs
+++ b/crates/compute/src/kernels/solve_joints_pbd_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Applies joint constraints to bodies using a PBD approach.
+///
+/// Bindings `[bodies_inout, joints_inout, params]` are expected and the updated
+/// bodies are returned in a single buffer.
 pub fn handle_solve_joints_pbd(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch(

--- a/crates/compute/src/kernels/sqrt_op.rs
+++ b/crates/compute/src/kernels/sqrt_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Computes the square root of each element in the input buffer.
+///
+/// Bindings are `[input, output_placeholder, config]` using `f32` data. The
+/// results are returned in a single buffer.
 pub fn handle_sqrt(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch("Sqrt kernel expects 3 buffers"));

--- a/crates/compute/src/kernels/sub_op.rs
+++ b/crates/compute/src/kernels/sub_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Element-wise subtraction of two buffers.
+///
+/// The function expects bindings `[a, b, output_placeholder, config]` where all
+/// buffers contain `f32` values of identical shape. The result buffer is
+/// returned as the sole entry in the returned vector.
 pub fn handle_sub(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         // IN1, IN2, OUT, CONFIG per layout.rs

--- a/crates/compute/src/kernels/tanh_op.rs
+++ b/crates/compute/src/kernels/tanh_op.rs
@@ -1,5 +1,9 @@
 use crate::{BufferView, ComputeError};
 
+/// Applies `tanh` to each element of the input buffer.
+///
+/// Bindings `[input, output_placeholder, config]` are expected with `f32` data.
+/// Returns one buffer containing the hyperbolic tangent of each input element.
 pub fn handle_tanh(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 3 {
         return Err(ComputeError::ShapeMismatch("Tanh kernel expects 3 buffers"));

--- a/crates/compute/src/kernels/where_op.rs
+++ b/crates/compute/src/kernels/where_op.rs
@@ -1,5 +1,10 @@
 use crate::{BufferView, ComputeError};
 
+/// Selects values from `true_val` or `false_val` based on a condition mask.
+///
+/// Bindings must be `[cond, true_val, false_val, output_placeholder]`. The
+/// condition buffer uses `u32` where zero represents `false`. The output buffer
+/// containing the chosen values is returned as a single entry.
 pub fn handle_where(binds: &[BufferView]) -> Result<Vec<Vec<u8>>, ComputeError> {
     if binds.len() < 4 {
         // cond, true_val, false_val, out_placeholder per layout.rs

--- a/crates/compute/src/layout.rs
+++ b/crates/compute/src/layout.rs
@@ -1,13 +1,20 @@
+/// Binding slot for the first input storage buffer.
 pub const STORAGE_IN: u32 = 0;
+/// Binding slot for the second input buffer used by binary operations.
 pub const STORAGE_IN2: u32 = 1; // binary ops
+/// Binding slot for the third input buffer used by ternary operations.
 pub const STORAGE_IN3: u32 = 2; // ternary ops (e.g. clamp input)
+/// Binding slot for the output storage buffer.
 pub const STORAGE_OUT: u32 = 3;
+/// Binding slot for uniform configuration data.
 pub const UNIFORM_SC: u32 = 4; // config, params, masks etc.
 
 const _: () = assert!(STORAGE_OUT == 3);
 
-/// Return expected number of bindings for each kernel.
-/// These are provisional and will be refined during TDD implementation of each op.
+/// Returns the expected number of buffer bindings for a given kernel.
+///
+/// The layout is stable across backends and used when creating bind groups.
+/// Values may evolve as kernels mature.
 pub const fn binding_count(kernel: &crate::Kernel) -> u32 {
     match kernel {
         // Element-wise

--- a/crates/compute/src/lib.rs
+++ b/crates/compute/src/lib.rs
@@ -26,6 +26,7 @@ pub use cpu_backend::CpuBackend;
 pub use wgpu_backend::WgpuBackend;
 
 #[derive(Error, Debug)]
+/// Errors that may occur when dispatching compute kernels.
 pub enum ComputeError {
     #[error("buffer shape mismatch: {0}")]
     ShapeMismatch(&'static str),
@@ -34,6 +35,7 @@ pub enum ComputeError {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+/// Enumeration of all compute kernels available in the crate.
 pub enum Kernel {
     // Element-wise
     Add,
@@ -80,6 +82,7 @@ pub enum Kernel {
 
 impl Kernel {
     #[must_use]
+    /// Returns the number of expected buffer bindings for this kernel.
     pub const fn binding_count(&self) -> u32 {
         layout::binding_count(self)
     }
@@ -104,6 +107,10 @@ pub struct BufferView {
 
 impl BufferView {
     #[must_use]
+    /// Creates a new buffer view over raw bytes.
+    ///
+    /// `shape` describes the logical tensor dimensions and `element_size_in_bytes`
+    /// specifies the size of each innermost element.
     pub fn new(data: Arc<[u8]>, shape: Vec<usize>, element_size_in_bytes: usize) -> Self {
         Self {
             data,


### PR DESCRIPTION
## Summary
- expand API documentation for compute crate
- document internal kernel helpers and backends

## Testing
- `cargo test -p compute`

------
https://chatgpt.com/codex/tasks/task_e_6846b5deefe88321905abe9b1b314a02