### PR TITLE
Rename project to JAXS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Differentiable-Physics
+# JAXS: Just Another Exploration Substrate
 
-This project aims to build a full stack physics and machine learning environment inspired by [Brax](https://github.com/google/brax) but designed around **WebGPU** and implemented entirely in Rust.  The goal is to provide fast differentiable physics, a compute backend that works on desktop and in browsers, and a minimal runtime for training ML policies directly against the simulator.
+JAXS aims to build a full stack physics and machine learning environment inspired by [Brax](https://github.com/google/brax) but designed around **WebGPU** and implemented entirely in Rust.  The goal is to provide fast differentiable physics, a compute backend that works on desktop and in browsers, and a minimal runtime for training ML policies directly against the simulator.
 
 > *See [VISION.md](VISION.md) for the long-term roadmap, including novelty-driven search with Dreamer V3.*
 

--- a/VISION.md
+++ b/VISION.md
@@ -1,6 +1,6 @@
-# Project Vision
+# JAXS Vision
 
-This repository aims to build a full stack differentiable physics and machine learning environment with a design inspired by [Brax](https://github.com/google/brax). Everything is implemented in **Rust** and targets **WebGPU** so that experiments can run efficiently on desktop GPUs and eventually in the browser. The long term goal is to explore rich artificial life through a combination of physics simulation, reinforcement learning, and evolutionary search.
+JAXS (Just Another Exploration Substrate) aims to build a full stack differentiable physics and machine learning environment with a design inspired by [Brax](https://github.com/google/brax). Everything is implemented in **Rust** and targets **WebGPU** so that experiments can run efficiently on desktop GPUs and eventually in the browser. The long term goal is to explore rich artificial life through a combination of physics simulation, reinforcement learning, and evolutionary search.
 
 ## Goals
 

--- a/crates/physics/src/lib.rs
+++ b/crates/physics/src/lib.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::module_name_repetitions)]
 //! # JAXS Physics Engine
 //!
-//! A minimal, differentiable physics engine for rigid body simulation.
+//! A minimal, differentiable physics engine for the JAXS project (Just Another Exploration Substrate).
 //!
 //! This crate provides the foundational physics layer for the JAXS project. It
 //! features a small set of rigid body types and a GPU-accelerated simulation

--- a/crates/render/src/lib.rs
+++ b/crates/render/src/lib.rs
@@ -3,7 +3,7 @@
 //! A simple `wgpu`-based rendering engine for visualizing physics simulations.
 //!
 //! This crate provides two lightweight rendering utilities for the JAXS
-//! project: [`Renderer`] and [`SdfRenderer`]. These renderers are designed to
+//! project (Just Another Exploration Substrate): [`Renderer`] and [`SdfRenderer`]. These renderers are designed to
 //! be simple and efficient, providing a convenient way to visualize the state
 //! of physics simulations during development and testing.
 //!

--- a/crates/render/src/renderer.rs
+++ b/crates/render/src/renderer.rs
@@ -72,7 +72,7 @@ impl Renderer {
     pub fn new() -> Result<Self> {
         let event_loop = EventLoop::new().context("create event loop")?;
         let window = WindowBuilder::new()
-            .with_title("Arena Renderer")
+            .with_title("JAXS Renderer")
             .build(&event_loop)
             .context("failed to create window")?;
 

--- a/crates/render/src/sdf_renderer.rs
+++ b/crates/render/src/sdf_renderer.rs
@@ -143,7 +143,7 @@ impl SdfRenderer {
     pub fn new() -> Result<Self> {
         let event_loop = EventLoop::new().context("create event loop")?;
         let window = WindowBuilder::new()
-            .with_title("Arena SDF Renderer")
+            .with_title("JAXS SDF Renderer")
             .build(&event_loop)
             .context("failed to create window")?;
 

--- a/crates/render/srcs/df_renderer.rs
+++ b/crates/render/srcs/df_renderer.rs
@@ -1,7 +1,7 @@
 pub fn new() -> Result<Self> {
     let event_loop = EventLoop::new().context("create event loop")?;
     let window = WindowBuilder::new()
-        .with_title("Differentiable Physics")
+        .with_title("JAXS Renderer")
         .with_maximized(true)
         .build(&event_loop)
         .context("failed to create window")?;

--- a/crates/runtime/src/app.rs
+++ b/crates/runtime/src/app.rs
@@ -1,6 +1,6 @@
 //! # JAXS Application Logic
 //!
-//! This module orchestrates the main simulation loop, integrating the physics engine,
+//! This module orchestrates the main simulation loop for JAXS (Just Another Exploration Substrate), integrating the physics engine,
 //! rendering, and live shader reloading capabilities.
 //!
 //! The primary function, [`run`], is the entry point for the application's core

--- a/crates/runtime/src/main.rs
+++ b/crates/runtime/src/main.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unnecessary_wraps)]
 //! # JAXS Runtime
 //!
-//! Entry point for the runtime binary.
+//! Entry point for the runtime binary of JAXS (Just Another Exploration Substrate).
 //!
 //! This crate ties together the compute, physics and optional rendering
 //! layers. A lightweight file watcher allows WGSL shaders to be hot reloaded

--- a/jaxs/Cargo.toml
+++ b/jaxs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "jaxs"
 version = "0.1.0"
 edition = "2021"
-description = "Documentation entry point for the JAXS project."
+description = "Documentation entry point for JAXS (Just Another Exploration Substrate)."
 
 [dependencies]
 compute = { path = "../crates/compute" }

--- a/jaxs/src/lib.rs
+++ b/jaxs/src/lib.rs
@@ -1,6 +1,6 @@
-//! # JAXS Project
+//! # JAXS: Just Another Exploration Substrate
 //!
-//! Welcome to the documentation for the JAXS project.
+//! Welcome to the documentation for JAXS (Just Another Exploration Substrate).
 //!
 //! JAXS is a differentiable physics engine and reinforcement learning framework
 //! for creating and training simulated creatures.


### PR DESCRIPTION
## Summary
- rename project to **JAXS** (Just Another Exploration Substrate)
- update documentation and crate descriptions
- adjust window titles in renderer modules

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846b8d8d47883219be32f45facccb18